### PR TITLE
Android x dependency overhaul

### DIFF
--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_aether_1_1_0_all_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_aether_1_1_0_all_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:aether-1.1.0-all:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/aether-1.1.0-all.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_annotations_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_annotations_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:annotations:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/annotations.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_asm_5_0_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_asm_5_0_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:asm-5.0.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/asm-5.0.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_asm_all_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_asm_all_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:asm-all:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/asm-all.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_asm_tree_5_0_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_asm_tree_5_0_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:asm-tree-5.0.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/asm-tree-5.0.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_automaton_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_automaton_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:automaton:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/automaton.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_baksmali_2_2_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_baksmali_2_2_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:baksmali-2.2.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/baksmali-2.2.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_batik_all_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_batik_all_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:batik-all:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/batik-all.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_bootstrap_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_bootstrap_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:bootstrap:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/bootstrap.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_cglib_nodep_3_2_4_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_cglib_nodep_3_2_4_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:cglib-nodep-3.2.4:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/cglib-nodep-3.2.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_cli_parser_1_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_cli_parser_1_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:cli-parser-1.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/cli-parser-1.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_common_io_3_2_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_common_io_3_2_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:common-io-3.2.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/common-io-3.2.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_common_lang_3_2_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_common_lang_3_2_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:common-lang-3.2.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/common-lang-3.2.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_commons_codec_1_9_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_commons_codec_1_9_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:commons-codec-1.9:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/commons-codec-1.9.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_commons_io_2_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_commons_io_2_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:commons-io-2.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/commons-io-2.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_commons_net_3_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_commons_net_3_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:commons-net-3.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/commons-net-3.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_coverage_agent_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_coverage_agent_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:coverage-agent:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/coverage-agent.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_coverage_util_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_coverage_util_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:coverage-util:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/coverage-util.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_dexlib2_2_2_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_dexlib2_2_2_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:dexlib2-2.2.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/dexlib2-2.2.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_ecj_4_7_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_ecj_4_7_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:ecj-4.7.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/ecj-4.7.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_eddsa_0_2_0_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_eddsa_0_2_0_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:eddsa-0.2.0:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/eddsa-0.2.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_emma_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_emma_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:emma:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/emma.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_extensions_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_extensions_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:extensions:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/extensions.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_fest_swing_1_4_4_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_fest_swing_1_4_4_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:fest-swing-1.4.4:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/fest-swing-1.4.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_fluent_hc_4_5_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_fluent_hc_4_5_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:fluent-hc-4.5.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/fluent-hc-4.5.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_forms_rt_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_forms_rt_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:forms_rt:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/forms_rt.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_fst_2_56_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_fst_2_56_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:fst-2.56:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/fst-2.56.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_gherkin_2_12_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_gherkin_2_12_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:gherkin-2.12.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/gherkin-2.12.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_gson_2_8_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_gson_2_8_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:gson-2.8.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/gson-2.8.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_guava_21_0_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_guava_21_0_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:guava-21.0:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/guava-21.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_httpclient_4_5_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_httpclient_4_5_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:httpclient-4.5.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/httpclient-4.5.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_httpcore_4_4_5_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_httpcore_4_4_5_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:httpcore-4.4.5:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/httpcore-4.4.5.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_httpmime_4_5_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_httpmime_4_5_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:httpmime-4.5.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/httpmime-4.5.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_icons_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_icons_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:icons:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/icons.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_idea_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_idea_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:idea:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/idea.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_idea_rt_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_idea_rt_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:idea_rt:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/idea_rt.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_imgscalr_lib_4_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_imgscalr_lib_4_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:imgscalr-lib-4.2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/imgscalr-lib-4.2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_ini4j_0_5_5_2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_ini4j_0_5_5_2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:ini4j-0.5.5-2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/ini4j-0.5.5-2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_isorelax_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_isorelax_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:isorelax:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/isorelax.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_java_api_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_java_api_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:java-api:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/java-api.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_java_impl_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_java_impl_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:java-impl:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/java-impl.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_javac2_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_javac2_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:javac2:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/javac2.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jaxen_1_1_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jaxen_1_1_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jaxen-1.1.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jaxen-1.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jayatana_1_2_4_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jayatana_1_2_4_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jayatana-1.2.4:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jayatana-1.2.4.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jbcrypt_1_0_0_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jbcrypt_1_0_0_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jbcrypt-1.0.0:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jbcrypt-1.0.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jdkAnnotations_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jdkAnnotations_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jdkAnnotations:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jdkAnnotations.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jdom_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jdom_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jdom:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jdom.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jediterm_pty_2_7_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jediterm_pty_2_7_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jediterm-pty-2.7:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jediterm-pty-2.7.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jgoodies_forms_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jgoodies_forms_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jgoodies-forms:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jgoodies-forms.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jh_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jh_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jh:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jh.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jimfs_1_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jimfs_1_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jimfs-1.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jimfs-1.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jing_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jing_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jing:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jing.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jna_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jna_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jna:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jna.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jna_platform_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jna_platform_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jna-platform:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jna-platform.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_builders_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_builders_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jps-builders:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jps-builders.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_builders_6_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_builders_6_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jps-builders-6:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jps-builders-6.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_launcher_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_launcher_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jps-launcher:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jps-launcher.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_model_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jps_model_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jps-model:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jps-model.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jsch_0_1_54_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jsch_0_1_54_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jsch-0.1.54:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jsch-0.1.54.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jshell_frontend_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jshell_frontend_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jshell-frontend:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jshell-frontend.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jshell_protocol_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jshell_protocol_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jshell-protocol:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jshell-protocol.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jsr173_1_0_api_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jsr173_1_0_api_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jsr173_1.0_api:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jsr173_1.0_api.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jsr305_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_jsr305_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:jsr305:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/jsr305.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_junit_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_junit_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:junit:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/junit.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_junit_4_12_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_junit_4_12_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:junit-4.12:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/junit-4.12.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_kotlin_reflect_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_kotlin_reflect_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:kotlin-reflect:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/kotlin-reflect.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_kotlin_runtime_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_kotlin_runtime_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:kotlin-runtime:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/kotlin-runtime.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_log4j_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_log4j_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:log4j:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/log4j.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_lz4_java_1_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_lz4_java_1_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:lz4-java-1.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/lz4-java-1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_microba_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_microba_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:microba:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/microba.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_nanoxml_2_2_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_nanoxml_2_2_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:nanoxml-2.2.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/nanoxml-2.2.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_nekohtml_1_9_14_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_nekohtml_1_9_14_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:nekohtml-1.9.14:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/nekohtml-1.9.14.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_objenesis_2_5_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_objenesis_2_5_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:objenesis-2.5.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/objenesis-2.5.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_openapi_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_openapi_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:openapi:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/openapi.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_oro_2_0_8_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_oro_2_0_8_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:oro-2.0.8:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/oro-2.0.8.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_picocontainer_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_picocontainer_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:picocontainer:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/picocontainer.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_platform_api_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_platform_api_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:platform-api:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/platform-api.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_platform_impl_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_platform_impl_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:platform-impl:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/platform-impl.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_proxy_vole_1_0_3_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_proxy_vole_1_0_3_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:proxy-vole-1.0.3:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/proxy-vole-1.0.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_pty4j_0_7_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_pty4j_0_7_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:pty4j-0.7.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/pty4j-0.7.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_purejavacomm_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_purejavacomm_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:purejavacomm:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/purejavacomm.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_resolver_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_resolver_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:resolver:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/resolver.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_resources_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_resources_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:resources:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/resources.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_resources_en_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_resources_en_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:resources_en:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/resources_en.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_serviceMessages_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_serviceMessages_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:serviceMessages:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/serviceMessages.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_slf4j_api_1_7_10_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_slf4j_api_1_7_10_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:slf4j-api-1.7.10:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/slf4j-api-1.7.10.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_snakeyaml_1_17_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_snakeyaml_1_17_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:snakeyaml-1.17:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/snakeyaml-1.17.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_streamex_0_6_5_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_streamex_0_6_5_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:streamex-0.6.5:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/streamex-0.6.5.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_trang_core_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_trang_core_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:trang-core:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/trang-core.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_trove4j_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_trove4j_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:trove4j:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/trove4j.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_util_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_util_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:util:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/util.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_util_2_2_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_util_2_2_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:util-2.2.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/util-2.2.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_velocity_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_velocity_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:velocity:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/velocity.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_wadl_core_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_wadl_core_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:wadl-core:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/wadl-core.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_winp_1_25_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_winp_1_25_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:winp-1.25:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/winp-1.25.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xbean_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xbean_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:xbean:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/xbean.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xercesImpl_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xercesImpl_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:xercesImpl:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/xercesImpl.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xmlrpc_2_0_1_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xmlrpc_2_0_1_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:xmlrpc-2.0.1:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/xmlrpc-2.0.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xpp3_1_1_4_min_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xpp3_1_1_4_min_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:xpp3-1.1.4-min:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/xpp3-1.1.4-min.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xstream_1_4_8_2018_1_5.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__com_jetbrains_xstream_1_4_8_2018_1_5.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="Gradle: com.jetbrains:xstream-1.4.8:2018.1.5">
+    <ANNOTATIONS>
+      <root url="jar://$MAVEN_REPOSITORY$/com/jetbrains/intellij/idea/ideaIU/2018.3.6/ideaIU-2018.3.6-annotations.zip!/" />
+    </ANNOTATIONS>
+    <CLASSES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/e1e20861201ac09734f77b9174e7c2465a611172/ideaIC-2018.1.5/lib/xstream-1.4.8.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2018.1.5/cfc53a4181dd404a59aadb0c2f6ea7d2eda6b726/ideaIC-2018.1.5-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/Plugin/test1/.idea/libraries/Gradle__tools.xml
+++ b/Plugin/test1/.idea/libraries/Gradle__tools.xml
@@ -1,0 +1,9 @@
+<component name="libraryTable">
+  <library name="Gradle: tools">
+    <CLASSES>
+      <root url="jar://C:/Program Files/Java/jdk1.8.0_151/lib/tools.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/android_prefetching_lib/android_prefetching_lib.iml
+++ b/android_prefetching_lib/android_prefetching_lib.iml
@@ -49,13 +49,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
@@ -63,6 +56,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -70,13 +70,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -84,6 +77,13 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/generated/not_namespaced_r_class_sources" />
       <excludeFolder url="file://$MODULE_DIR$/build/generated/source/r" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/aapt_friendly_merged_manifests" />
@@ -112,49 +112,64 @@
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 27 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 28 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence.room:runtime:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata-core:1.1.0@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: android.arch.persistence.room:testing:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:common:1.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:27.1.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:viewmodel:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence:db:1.0.0@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test.espresso:espresso-idling-resource:3.0.2@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test:runner:1.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.2@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.core:runtime:1.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.drawerlayout:drawerlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.documentfile:documentfile:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.localbroadcastmanager:localbroadcastmanager:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-runtime:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata-core:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.cursoradapter:cursoradapter:1.0.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.squareup:javawriter:2.1.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: android.arch.persistence.room:migration:1.0.0@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test.espresso:espresso-core:3.0.2@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test.espresso:espresso-core:3.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.customview:customview:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.core:core:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:runner:1.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.17.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.room:room-runtime:2.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.asynclayoutinflater:asynclayoutinflater:1.0.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.google.code.gson:gson:2.8.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:extensions:1.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.sqlite:sqlite:2.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.interpolator:interpolator:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.fragment:fragment:1.0.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains:annotations:13.0@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.google.code.findbugs:jsr305:2.0.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.14.0@jar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: javax.inject:javax.inject:1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: io.reactivex.rxjava2:rxjava:2.1.15@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-compat:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: org.bitbucket.cowwoc:diff-match-patch:1.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.10.0@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.1.3@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-fragment:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test:monitor:1.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence.room:common:1.0.0@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-library:1.3@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-integration:1.3@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.core:common:1.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence:db-framework:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-service:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.slidingpanelayout:slidingpanelayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib-common:1.3.31@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.arch.core:core-runtime:2.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.coordinatorlayout:coordinatorlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test.espresso:espresso-idling-resource:3.2.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: net.sf.kxml:kxml2:2.3.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.annotation:annotation:1.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.swiperefreshlayout:swiperefreshlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.jetbrains.kotlin:kotlin-stdlib:1.3.31@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.viewpager:viewpager:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-ui:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.loader:loader:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.14.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-common:2.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-utils:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.print:print:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.versionedparcelable:versionedparcelable:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.google.code.findbugs:jsr305:2.0.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-viewmodel:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: io.reactivex.rxjava2:rxjava:2.1.15@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.arch.core:core-common:2.0.1@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: org.bitbucket.cowwoc:diff-match-patch:1.1@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.room:room-testing:2.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.room:room-common:2.1.0@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:monitor:1.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.sqlite:sqlite-framework:2.0.1@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.room:room-migration:2.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-extensions:2.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-integration:1.3@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-library:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.collection:collection:1.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-process:2.0.0@aar" level="project" />
   </component>
 </module>

--- a/android_prefetching_lib/build.gradle
+++ b/android_prefetching_lib/build.gradle
@@ -1,17 +1,17 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
 
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 
@@ -31,15 +31,15 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
         testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    def roomVersion = "1.0.0"
-    implementation "android.arch.persistence.room:runtime:$roomVersion"
-    annotationProcessor "android.arch.persistence.room:compiler:$roomVersion"
-    androidTestImplementation "android.arch.persistence.room:testing:$roomVersion"
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
-    implementation 'android.arch.lifecycle:extensions:1.1.0'
-    annotationProcessor "android.arch.lifecycle:compiler:1.1.0"
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+
+    implementation 'androidx.room:room-runtime:2.1.0'
+    annotationProcessor 'androidx.room:room-compiler:2.1.0'
+    androidTestImplementation 'androidx.room:room-testing:2.1.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.2'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.15'
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.1'
     implementation files('libs')

--- a/android_prefetching_lib/src/androidTest/java/nl/vu/cs/s2group/ExampleInstrumentedTest.java
+++ b/android_prefetching_lib/src/androidTest/java/nl/vu/cs/s2group/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/PrefetchingLib.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/PrefetchingLib.java
@@ -1,11 +1,11 @@
 package nl.vu.cs.s2group;
 
 import android.app.Activity;
-import android.arch.lifecycle.LiveData;
+import androidx.lifecycle.LiveData;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Environment;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 import android.util.LongSparseArray;
 import android.util.LruCache;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/graph/ActivityNode.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/graph/ActivityNode.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.graph;
 
-import android.arch.lifecycle.LiveData;
+import androidx.lifecycle.LiveData;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategy.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategy.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.Arrays;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl2.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl2.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl3.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl3.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl4.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl4.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl5.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl5.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl6.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl6.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl7.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl7.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl8.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl8.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl9.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetch/PrefetchStrategyImpl9.java
@@ -20,7 +20,7 @@
 
 package nl.vu.cs.s2group.prefetch;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.HashMap;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetchurl/ParameteredUrl.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/prefetchurl/ParameteredUrl.java
@@ -1,6 +1,6 @@
 package nl.vu.cs.s2group.prefetchurl;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/ActivityData.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/ActivityData.java
@@ -1,9 +1,9 @@
 package nl.vu.cs.s2group.room;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 
 @Entity(tableName = "pf_activity", indices = @Index(value = {"activity_name"}, unique = true))
 public class ActivityData {

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/ActivityTableDao.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/ActivityTableDao.java
@@ -1,10 +1,10 @@
 package nl.vu.cs.s2group.room;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
 
 import java.util.List;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/AggregateUrlDao.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/AggregateUrlDao.java
@@ -1,9 +1,9 @@
 package nl.vu.cs.s2group.room;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
 
 import java.util.List;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/PrefetchingDatabase.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/PrefetchingDatabase.java
@@ -1,9 +1,9 @@
 package nl.vu.cs.s2group.room;
 
 
-import android.arch.persistence.room.Database;
-import android.arch.persistence.room.Room;
-import android.arch.persistence.room.RoomDatabase;
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
 import android.content.Context;
 
 import nl.vu.cs.s2group.room.dao.ActivityExtraDao;

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/RequestData.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/RequestData.java
@@ -1,9 +1,9 @@
 package nl.vu.cs.s2group.room;
 
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 /**
  * Represents all data corresponding to an http request

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/ActivityExtraDao.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/ActivityExtraDao.java
@@ -1,9 +1,9 @@
 package nl.vu.cs.s2group.room.dao;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
 
 import java.util.List;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/GraphEdgeDao.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/GraphEdgeDao.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.room.dao;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Query;
+import androidx.room.Dao;
+import androidx.room.Query;
 
 import java.util.List;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/SessionDao.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/SessionDao.java
@@ -1,10 +1,10 @@
 package nl.vu.cs.s2group.room.dao;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
 
 import java.util.List;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/UrlCandidateDao.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/dao/UrlCandidateDao.java
@@ -1,10 +1,10 @@
 package nl.vu.cs.s2group.room.dao;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
 import android.util.ArrayMap;
 import android.util.Log;
 

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/ActivityExtraData.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/ActivityExtraData.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.room.data;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 @Entity(tableName = "pf_activity_extra")
 public class ActivityExtraData {

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/LARData.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/LARData.java
@@ -1,9 +1,9 @@
 package nl.vu.cs.s2group.room.data;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.Index;
-import android.support.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.Index;
+import androidx.annotation.NonNull;
 
 @Entity(tableName = "pf_LAR", primaryKeys = {"activity_name"}, indices = @Index(value = {"activity_name"}, unique = true))
 public class LARData {

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/Session.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/Session.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.room.data;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 @Entity(tableName = "pf_session")
 public class Session {

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/SessionData.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/SessionData.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.room.data;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.support.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.annotation.NonNull;
 
 @Entity(tableName = "pf_session_data", primaryKeys = {"id_session", "id_activity_source", "id_activity_destination"})
 public class SessionData {

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/UrlCandidate.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/UrlCandidate.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.room.data;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 /**
  * Represents an individual URL candidate

--- a/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/UrlCandidateParts.java
+++ b/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/room/data/UrlCandidateParts.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.room.data;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
 
 /**
  * Represents an individual part of a URL candidate, which can either be a statically defined piece of an URL,

--- a/app/app.iml
+++ b/app/app.iml
@@ -98,6 +98,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-apk" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-resources" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_app_manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_run_app_info_output_file" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant_run_main_apk_resources" />
@@ -126,53 +127,68 @@
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 27 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 28 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence.room:runtime:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:recyclerview-v7:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-vector-drawable:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-core-utils:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata-core:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:runtime:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:transition:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:common:1.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-annotations:27.1.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:viewmodel:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.google.code.gson:gson:2.8.5@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence:db:1.0.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout:1.1.2@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test.espresso:espresso-idling-resource:3.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-v4:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:cardview-v7:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test:runner:1.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.2@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:design:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.core:runtime:1.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.android.material:material:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.drawerlayout:drawerlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.documentfile:documentfile:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.localbroadcastmanager:localbroadcastmanager:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.cardview:cardview:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.recyclerview:recyclerview:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-runtime:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata-core:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.cursoradapter:cursoradapter:1.0.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: com.squareup:javawriter:2.1.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:animated-vector-drawable:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test.espresso:espresso-core:3.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:extensions:1.1.0@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.google.code.findbugs:jsr305:2.0.1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.14.0@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test.espresso:espresso-core:3.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.customview:customview:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:runner:1.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okio:okio:1.17.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.room:room-runtime:2.1.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.asynclayoutinflater:asynclayoutinflater:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.vectordrawable:vectordrawable:1.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.sqlite:sqlite:2.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.interpolator:interpolator:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.fragment:fragment:1.0.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: javax.inject:javax.inject:1@jar" level="project" />
-    <orderEntry type="library" name="Gradle: io.reactivex.rxjava2:rxjava:2.1.15@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-core-ui:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-compat:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.lifecycle:livedata:1.1.0@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-media-compat:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.10.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support.constraint:constraint-layout-solver:1.1.2@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:support-fragment:27.1.1@aar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: com.android.support.test:monitor:1.0.2@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence.room:common:1.0.0@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-library:1.3@jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-integration:1.3@jar" level="project" />
-    <orderEntry type="library" name="Gradle: com.android.support:appcompat-v7:27.1.1@aar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.core:common:1.1.0@jar" level="project" />
-    <orderEntry type="library" name="Gradle: android.arch.persistence:db-framework:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-service:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.slidingpanelayout:slidingpanelayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.arch.core:core-runtime:2.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.coordinatorlayout:coordinatorlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test.espresso:espresso-idling-resource:3.2.0@aar" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: net.sf.kxml:kxml2:2.3.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.annotation:annotation:1.1.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.swiperefreshlayout:swiperefreshlayout:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.viewpager:viewpager:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-ui:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.loader:loader:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: com.google.code.gson:gson:2.8.5@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.appcompat:appcompat:1.0.2@aar" level="project" />
+    <orderEntry type="library" name="Gradle: org.reactivestreams:reactive-streams:1.0.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: com.squareup.okhttp3:okhttp:3.14.2@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-livedata:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.constraintlayout:constraintlayout:1.1.3@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.vectordrawable:vectordrawable-animated:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-common:2.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.legacy:legacy-support-core-utils:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.print:print:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.versionedparcelable:versionedparcelable:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.constraintlayout:constraintlayout-solver:1.1.3@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: com.google.code.findbugs:jsr305:2.0.1@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-viewmodel:2.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: io.reactivex.rxjava2:rxjava:2.1.15@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.transition:transition:1.0.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.arch.core:core-common:2.0.1@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: junit:junit:4.12@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-core:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.room:room-common:2.1.0@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: androidx.test:monitor:1.2.0@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.sqlite:sqlite-framework:2.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-extensions:2.0.0@aar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-integration:1.3@jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.hamcrest:hamcrest-library:1.3@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.core:core:1.0.1@aar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.collection:collection:1.0.0@jar" level="project" />
+    <orderEntry type="library" name="Gradle: androidx.lifecycle:lifecycle-process:2.0.0@aar" level="project" />
     <orderEntry type="module" module-name="android_prefetching_lib" />
   </component>
 </module>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "nl.cs.vu.android_prefetching_2018"
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -23,20 +23,20 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'com.google.android.material:material:1.0.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.2'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.android.support:cardview-v7:27.1.1'
+    implementation 'androidx.cardview:cardview:1.0.0'
     implementation project(path: ':android_prefetching_lib')
     def roomVersion = "1.0.0"
-    implementation "android.arch.persistence.room:runtime:$roomVersion"
-    implementation 'android.arch.lifecycle:extensions:1.1.0'
-    annotationProcessor "android.arch.lifecycle:compiler:1.1.0"
+    implementation 'androidx.room:room-runtime:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.15'
 
 }

--- a/app/src/androidTest/java/nl/vu/cs/s2group/android_prefetching_2018/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/nl/vu/cs/s2group/android_prefetching_2018/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.InstrumentationRegistry;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/CapitalListActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/CapitalListActivity.java
@@ -1,13 +1,13 @@
 package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.design.widget.TextInputEditText;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
+import com.google.android.material.textfield.TextInputEditText;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.appcompat.widget.Toolbar;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.Observable;
-import nl.vu.cs.s2group.android_prefetching_2018.R;
 import nl.vu.cs.s2group.android_prefetching_2018.cardview.CapitalCardViewAdapter;
 import nl.vu.cs.s2group.android_prefetching_2018.cardview.CapitalCardViewAdapterObservable;
 import nl.vu.cs.s2group.android_prefetching_2018.data.Capital;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/CityDetailsActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/CityDetailsActivity.java
@@ -1,11 +1,10 @@
 package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.content.Intent;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.widget.Button;
 
-import nl.vu.cs.s2group.android_prefetching_2018.R;
 import nl.vu.cs.s2group.PrefetchingLib;
 
 public class CityDetailsActivity extends AppCompatActivity {

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/InterActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/InterActivity.java
@@ -2,11 +2,10 @@ package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.widget.Button;
 
-import nl.vu.cs.s2group.android_prefetching_2018.R;
 import nl.vu.cs.s2group.PrefetchingLib;
 
 public class InterActivity extends AppCompatActivity {

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/MainActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/MainActivity.java
@@ -1,14 +1,13 @@
 package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.content.Intent;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Button;
 
-import nl.vu.cs.s2group.android_prefetching_2018.R;
 import nl.vu.cs.s2group.android_prefetching_2018.network.OkHttpProvider;
 import nl.vu.cs.s2group.android_prefetching_2018.stats.ListActivityActivity;
 import nl.vu.cs.s2group.android_prefetching_2018.stats.SessionDataActivity;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/NewsActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/NewsActivity.java
@@ -2,12 +2,12 @@ package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.view.View;
 
@@ -15,7 +15,6 @@ import com.google.gson.Gson;
 
 import java.io.IOException;
 
-import nl.vu.cs.s2group.android_prefetching_2018.R;
 import nl.vu.cs.s2group.android_prefetching_2018.cardview.NewsCardViewAdapter;
 import nl.vu.cs.s2group.android_prefetching_2018.data.NewsWrapper;
 import nl.vu.cs.s2group.android_prefetching_2018.network.OkHttpProvider;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/WeatherActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/WeatherActivity.java
@@ -2,11 +2,11 @@ package nl.vu.cs.s2group.android_prefetching_2018;
 
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.widget.TextView;
 
@@ -15,7 +15,6 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Date;
 
-import nl.vu.cs.s2group.android_prefetching_2018.R;
 import nl.vu.cs.s2group.android_prefetching_2018.data.Weather;
 import nl.vu.cs.s2group.android_prefetching_2018.network.OkHttpProvider;
 import nl.vu.cs.s2group.PrefetchingLib;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/cardview/CapitalCardViewAdapter.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/cardview/CapitalCardViewAdapter.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.android_prefetching_2018.cardview;
 
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/cardview/CapitalCardViewAdapterObservable.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/cardview/CapitalCardViewAdapterObservable.java
@@ -1,8 +1,8 @@
 package nl.vu.cs.s2group.android_prefetching_2018.cardview;
 
 import android.content.Intent;
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/cardview/NewsCardViewAdapter.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/cardview/NewsCardViewAdapter.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.android_prefetching_2018.cardview;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/AggregateViewModel.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/AggregateViewModel.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.android_prefetching_2018.stats;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
 
 import java.util.List;
 

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/ListActivityActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/ListActivityActivity.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.android_prefetching_2018.stats;
 
-import android.arch.lifecycle.ViewModelProviders;
-import android.support.v7.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.widget.TextView;
 

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/SessionDataActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/SessionDataActivity.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.android_prefetching_2018.stats;
 
-import android.arch.lifecycle.ViewModelProviders;
-import android.support.v7.app.AppCompatActivity;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.widget.TextView;
 

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/StatsActivity.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/stats/StatsActivity.java
@@ -1,11 +1,11 @@
 package nl.vu.cs.s2group.android_prefetching_2018.stats;
 
-import android.arch.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProvider;
 import android.os.Bundle;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.view.View;
 import android.widget.TextView;
 

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/viewmodel/ViewModelActivityList.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/viewmodel/ViewModelActivityList.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.android_prefetching_2018.viewmodel;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
 
 import java.util.List;
 

--- a/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/viewmodel/ViewModelSessionDataList.java
+++ b/app/src/main/java/nl/vu/cs/s2group/android_prefetching_2018/viewmodel/ViewModelSessionDataList.java
@@ -1,7 +1,7 @@
 package nl.vu.cs.s2group.android_prefetching_2018.viewmodel;
 
-import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.ViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
 
 import java.util.List;
 

--- a/app/src/main/res/layout/activity_capital_list.xml
+++ b/app/src/main/res/layout/activity_capital_list.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.CapitalListActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_capital_list" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -30,4 +30,4 @@
         android:layout_margin="@dimen/fab_margin"
         app:srcCompat="@android:drawable/ic_dialog_email" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_city_details.xml
+++ b/app/src/main/res/layout/activity_city_details.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -17,4 +17,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_graph.xml
+++ b/app/src/main/res/layout/activity_graph.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.GraphActivity">
@@ -21,5 +21,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_inter.xml
+++ b/app/src/main/res/layout/activity_inter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -66,4 +66,4 @@
 
     </RelativeLayout>
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_list_activity.xml
+++ b/app/src/main/res/layout/activity_list_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -17,4 +17,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -39,4 +39,4 @@
         app:layout_constraintStart_toStartOf="@+id/button_news"
         app:layout_constraintTop_toBottomOf="@+id/button_news" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_news.xml
+++ b/app/src/main/res/layout/activity_news.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.NewsActivity">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:layout_marginTop="?attr/actionBarSize"
         android:id="@+id/recycler_news"
         android:layout_width="match_parent"
@@ -14,25 +14,25 @@
         >
 
 
-    </android.support.v7.widget.RecyclerView>
+    </androidx.recyclerview.widget.RecyclerView>
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_news" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -40,4 +40,4 @@
         android:layout_margin="@dimen/fab_margin"
         app:srcCompat="@android:drawable/ic_dialog_email" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_session_data.xml
+++ b/app/src/main/res/layout/activity_session_data.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.stats.SessionDataActivity">
@@ -20,5 +20,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/activity_stats.xml
+++ b/app/src/main/res/layout/activity_stats.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.stats.StatsActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_stats" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -30,4 +30,4 @@
         android:layout_margin="@dimen/fab_margin"
         app:srcCompat="@android:drawable/ic_dialog_email" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_weather.xml
+++ b/app/src/main/res/layout/activity_weather.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.WeatherActivity">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/AppTheme.AppBarOverlay">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_weather" />
 
-    <android.support.design.widget.FloatingActionButton
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -30,4 +30,4 @@
         android:layout_margin="@dimen/fab_margin"
         app:srcCompat="@android:drawable/ic_dialog_email" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/card_capitals.xml
+++ b/app/src/main/res/layout/card_capitals.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,7 +7,7 @@
     android:layout_margin="2dp"
     app:cardUseCompatPadding="true">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -34,6 +34,6 @@
             app:layout_constraintEnd_toEndOf="@+id/text_country"
             app:layout_constraintStart_toStartOf="@+id/text_country"
             app:layout_constraintTop_toBottomOf="@+id/text_country" />
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/card_news.xml
+++ b/app/src/main/res/layout/card_news.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_margin="16dp"
@@ -51,5 +51,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/imageView" />
-    </android.support.constraint.ConstraintLayout>
-</android.support.v7.widget.CardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/content_capital_list.xml
+++ b/app/src/main/res/layout/content_capital_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -7,7 +7,7 @@
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.CapitalListActivity"
     tools:showIn="@layout/activity_capital_list">
-    <android.support.design.widget.TextInputLayout
+    <com.google.android.material.textfield.TextInputLayout
         android:visibility="gone"
         android:id="@+id/textInputLayout"
         android:layout_width="368dp"
@@ -19,15 +19,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <android.support.design.widget.TextInputEditText
+        <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/text_capital_filter"
             android:inputType="textFilter"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Capital City name" />
-    </android.support.design.widget.TextInputLayout>
+    </com.google.android.material.textfield.TextInputLayout>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_capitals"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -40,4 +40,4 @@
         app:layout_constraintTop_toBottomOf="@+id/textInputLayout" />
 
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_inter.xml
+++ b/app/src/main/res/layout/content_inter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,4 +8,4 @@
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.InterActivity"
     tools:showIn="@layout/activity_inter">
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_news.xml
+++ b/app/src/main/res/layout/content_news.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,4 +8,4 @@
     tools:context="nl.vu.cs.s2group.android_prefetching_2018.NewsActivity"
     tools:showIn="@layout/activity_news">
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_stats.xml
+++ b/app/src/main/res/layout/content_stats.xml
@@ -7,7 +7,7 @@
 
     android:layout_marginTop="?attr/actionBarSize"
     >
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
@@ -26,5 +26,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/layout/content_weather.xml
+++ b/app/src/main/res/layout/content_weather.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -19,4 +19,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
This pull request Changes all android dependencies to their latest safe version.   Also,  it moves the Target and Compile SDK up to android 28.  The rationale is to allow developers to resolve dependency issues by using Android's Jetifier and AndroidX, in order to minimize the amount of manual dependency resolution.  Jetifier is able to resolve dependencies automatically, and instead of managing all different versions of Appcompat (for example),  All dependencies are joined to AndroidX
