### PR TITLE
23/remove local variable from gradle build

### DIFF
--- a/Plugin/test1/build.gradle
+++ b/Plugin/test1/build.gradle
@@ -8,6 +8,12 @@ version '1.7-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
+// When this option is enabled and `ideDirectory` is set to Android Studio,
+// the build fails and generates the exception https://youtrack.jetbrains.com/issue/KT-32401
+// As a result of disabling building searchable options,
+// the configurables that your plugin provides won't be searchable in the Settings dialog.
+buildSearchableOptions.enabled = false
+
 repositories {
     mavenCentral()
 }
@@ -17,10 +23,21 @@ dependencies {
 }
 
 intellij {
-    version '2020.1.1'
+    // Refer to the docs for more information
+    // https://github.com/JetBrains/gradle-intellij-plugin
+    // https://www.jetbrains.org/intellij/sdk/docs/products/android_studio.html
+    version '192.7142.36' // Android studio build; version = 3.6.3
+    type 'IC'
 
-    plugins 'android'
+    plugins 'android',
+            'java'
+
     updateSinceUntilBuild false
+}
+
+// TODO: Verify possibility of defining runIde as a local configuration only
+runIde {
+    ideDirectory '/opt/android-studio/'
 }
 
 patchPluginXml {

--- a/Plugin/test1/build.gradle
+++ b/Plugin/test1/build.gradle
@@ -26,8 +26,8 @@ intellij {
     // Refer to the docs for more information
     // https://github.com/JetBrains/gradle-intellij-plugin
     // https://www.jetbrains.org/intellij/sdk/docs/products/android_studio.html
-    version '192.7142.36' // Android studio build; version = 3.6.3
-    type 'IC'
+    // Needs to be defined in the Gradle installation directory
+    version nappaAndroidStudiVersion
 
     plugins 'android',
             'java'

--- a/Plugin/test1/build.gradle
+++ b/Plugin/test1/build.gradle
@@ -35,9 +35,9 @@ intellij {
     updateSinceUntilBuild false
 }
 
-// TODO: Verify possibility of defining runIde as a local configuration only
 runIde {
-    ideDirectory '/opt/android-studio/'
+    // Needs to be defined in the Gradle installation directory
+    ideDirectory nappaAndroidStudioHome
 }
 
 patchPluginXml {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Use "Spot OkHttp" to instrument OkHttp Builder in order to track HTTP/GET reques
 use "Add prefetching" to instrument Activities in order to get the navigation graph
 
 After the instrumentation process takes place, NAPPA performs the ENG construction dynamically. Prefetching is performed transparently without requiring any intervention from the end user.  As the user navigates an application's activities, the ENG is built and prefetching is performed whenever a suitable candidate is encountered.
+
+### Set up local environment for development
+
+#### Android Studio Plugin
+
+Install the following toos:
+
+- [Gradle](https://gradle.org/)
+- [IntelliJ IDEA](https://www.jetbrains.com/idea/)
+- [Android Studio](https://developer.android.com/studio)
+
+Create the file `gradle.properties` in the Gradle installation direcctory with the content:
+```text
+nappaAndroidStudioHome=/absolute/path/to/Android Studio/
+```
+
+Import the directory [Plugin/test1/](Plugin/test1/) in InteliJ IDEA
+
+Open the [Gradle tool window](https://www.jetbrains.com/help/idea/jetgradle-tool-window.html#)
+
+Click on `test1 > Tasks > IntelliJ > runIde` to open an instance of Android Studio with the plugin installed. 
+This instance can be run in debug mode.
+Note that changes in the source code require running the command again to take effect. 
+
 ## How to cite NAPPA
 If NAPPA is helping your research, consider to cite is as follows, thanks!
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In this case, the (BRANCH.BUILD.FIX) version of the IntelliJ Platform is `191.80
 Refer to [Android Studio Plugin Development](https://www.jetbrains.org/intellij/sdk/docs/products/android_studio.html) for more details.
 
  <p align="center">
- <img src="https://www.jetbrains.org/intellij/sdk/docs/products/img/android_studio_build.png" alt="Nappa Android Studio Plugin" width="500"/>
+ <img src="https://www.jetbrains.org/intellij/sdk/docs/products/img/android_studio_build.png" alt="Android Studio aboud dialog screen" width="500"/>
  </p>
 
 Import the directory [Plugin/test1/](Plugin/test1/) in InteliJ IDEA


### PR DESCRIPTION
Replace the direct usage of the local environment values for local variables defined in the user Gradle home directory.

Add a section in the readme on how to set up the local development for the plugin

Close #23 