### PR TITLE
Standardize logging statements

### DIFF
--- a/Prefetching-Library/android_prefetching_lib/build.gradle
+++ b/Prefetching-Library/android_prefetching_lib/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0+1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/PrefetchingLib.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/PrefetchingLib.java
@@ -510,7 +510,7 @@ public class PrefetchingLib {
                 prefetchUrls(toBePrefetched);
             }
             /*for (String url : toBePrefetched) {
-                Log.d(LOG_TAG, "URL: "+url);
+                Log.e("PREFSTRAT2", "URL: "+url);
                 Request request = new Request.Builder().get().url(url).build();
                 try {
                     okHttpClient.newCall(request).execute();

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/PrefetchingLib.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/PrefetchingLib.java
@@ -218,7 +218,7 @@ public class PrefetchingLib {
                 listLiveData.observeForever(new Observer<List<ActivityData>>() {
                     @Override
                     public void onChanged(@Nullable List<ActivityData> activityData) {
-                        Log.d(LOG_TAG, "Added/Removed/Updated a new Activity");
+                        Log.i("PREFETCHINGLIB", "Added/Removed/Updated a new Activity");
                         synchronized (activityMap) {
                             updateActivityMap(activityData);
                         }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityGraph.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityGraph.java
@@ -14,6 +14,7 @@ import nl.vu.cs.s2group.nappa.room.data.LARData;
 
 
 public class ActivityGraph {
+    private final static String LOG_TAG = ActivityGraph.class.getSimpleName();
 
     List<ActivityNode> nodeList;
     ActivityNode current = null;
@@ -28,30 +29,30 @@ public class ActivityGraph {
      * @param activityName The activity 
      */
     public void initNodes(String activityName) {
-        Log.w("ACT_GRAPH", "initNodes() fired for node: " + activityName);
+        Log.d(LOG_TAG, "ACT_GRAPH " + "initNodes() fired for node: " + activityName);
         ActivityNode temp = new ActivityNode(activityName);
         //link analysis ranking (LAR)
         LARData LAR = PrefetchingDatabase.getInstance().activityDao().getLAR(activityName);
-        Log.d("LARDataInitFetchDB",activityName+" Pagerank: "+LAR.PR+" HITS-Authority: "+LAR.authority+" HITS-Hub: "+LAR.hub+" SALSA-Authority: "+LAR.authorityS+" SALSA-Hub: "+LAR.hubS);
+        Log.d(LOG_TAG, "LARDataInitFetchDB " +activityName+" Pagerank: "+LAR.PR+" HITS-Authority: "+LAR.authority+" HITS-Hub: "+LAR.hub+" SALSA-Authority: "+LAR.authorityS+" SALSA-Hub: "+LAR.hubS);
 
         // Verify if the current activity node already exists in the activity graph
         if (nodeList.contains(temp)) {
             temp = nodeList.get(nodeList.lastIndexOf(temp));
-            Log.d("LARDataInit","already in nodeList");
+            Log.d(LOG_TAG, "LARDataInit " +"already in nodeList");
         } else {
             temp.pageRank = LAR.PR;
             temp.authority = LAR.authority;
             temp.hub = LAR.hub;
             temp.authorityS = LAR.authorityS;
             temp.hubS = LAR.hubS;
-            Log.d("LARDataInit","node "+ temp.activityName+" added to nodeList");
+            Log.d(LOG_TAG, "LARDataInit " +"node "+ temp.activityName+" added to nodeList");
             nodeList.add(temp);
         }
 
 
         // Get all edges (destinations) for a given activity (source)
         List<GraphEdgeDao.GraphEdge> edges = PrefetchingDatabase.getInstance().graphEdgeDao().getEdgesForActivity(activityName);
-        Log.w("ACT_GRAPH", "Edges size: " + edges.size());
+        Log.d(LOG_TAG, "ACT_GRAPH " + "Edges size: " + edges.size());
 
 
         // Verify if all edges (destinations) for this activity already exists in the
@@ -62,26 +63,26 @@ public class ActivityGraph {
             if (edge != null && edge.actName != null) {
                 ActivityNode temp2 = new ActivityNode(edge.actName);
                 LAR = PrefetchingDatabase.getInstance().activityDao().getLAR(edge.actName);
-                Log.d("LARDataInitFetchDB",activityName+" Pagerank: "+LAR.PR+" HITS-Authority: "+LAR.authority+" HITS-Hub: "+LAR.hub+" SALSA-Authority: "+LAR.authorityS+" SALSA-Hub: "+LAR.hubS+" loaded following an edge");
+                Log.d(LOG_TAG, "LARDataInitFetchDB " +activityName+" Pagerank: "+LAR.PR+" HITS-Authority: "+LAR.authority+" HITS-Hub: "+LAR.hub+" SALSA-Authority: "+LAR.authorityS+" SALSA-Hub: "+LAR.hubS+" loaded following an edge");
 
                 if (nodeList.contains(temp2)) {
-                    Log.w("ACT_GRAPH", "contains temp2");
-                    Log.d("LARDataInit","already in nodeList from edge");
+                    Log.d(LOG_TAG, "ACT_GRAPH " + "contains temp2");
+                    Log.d(LOG_TAG, "LARDataInit " +"already in nodeList from edge");
                     temp2 = nodeList.get(nodeList.lastIndexOf(temp2));
                 } else {
-                    Log.w("ACT_GRAPH", "does not contain temp2");
+                    Log.d(LOG_TAG, "ACT_GRAPH " + "does not contain temp2");
                     temp2.pageRank = LAR.PR;
                     temp2.authority = LAR.authority;
                     temp2.hub = LAR.hub;
                     temp2.authorityS = LAR.authorityS;
                     temp2.hubS = LAR.hubS;
-                    Log.d("LARDataInit","node "+ temp2.activityName+" added to nodeList from edge");
+                    Log.d(LOG_TAG, "LARDataInit " +"node "+ temp2.activityName+" added to nodeList from edge");
                     nodeList.add(temp2);
                 }
 
                 //  Add the Source-Successor relationship to both the database and the temp node itself
                 temp.initSuccessor(temp2);
-                Log.w("ACT_GRAPH", "adding successors: " + temp.activityName + " -> " + temp2.activityName);
+                Log.d(LOG_TAG, "ACT_GRAPH " + "adding successors: " + temp.activityName + " -> " + temp2.activityName);
             }
         }
 
@@ -119,8 +120,8 @@ public class ActivityGraph {
             poolExecutor.schedule(() -> {
                 PrefetchingDatabase.getInstance().activityDao().insertLAR(new LARData(tempActivityName,initialPageRank,initialAuthority,initialHub,initialAuthorityS,initialHubS));
             }, 0, TimeUnit.SECONDS);
-            Log.d("LARDataUpdate","node "+temp.activityName+" added to nodelist");
-            Log.d("LARDataUpdate"," Pagerank: "+temp.pageRank+" HITS-Authority: "+temp.authority+" HITS-Hub: "+temp.hub+" SALSA-Authority: "+temp.authorityS+" SALSA-Hub: "+temp.hubS);
+            Log.d(LOG_TAG, "LARDataUpdate " +"node "+temp.activityName+" added to nodelist");
+            Log.d(LOG_TAG, "LARDataUpdate " +" Pagerank: "+temp.pageRank+" HITS-Authority: "+temp.authority+" HITS-Hub: "+temp.hub+" SALSA-Authority: "+temp.authorityS+" SALSA-Hub: "+temp.hubS);
         }
         if (current!=null) {
             shouldPrefetch = current.addSuccessor(temp);
@@ -128,7 +129,7 @@ public class ActivityGraph {
             //updates
             updateLAR(activityName);
             temp = nodeList.get(nodeList.lastIndexOf(temp));
-            Log.d("LARDataCalculatedUpdate",temp.activityName+" Pagerank: "+temp.pageRank+" HITS-Authority: "+temp.authority+" HITS-Hub: "+temp.hub+" SALSA-Authority: "+temp.authorityS+" SALSA-Hub: "+temp.hubS);
+            Log.d(LOG_TAG, "LARDataCalculatedUpdate " +temp.activityName+" Pagerank: "+temp.pageRank+" HITS-Authority: "+temp.authority+" HITS-Hub: "+temp.hub+" SALSA-Authority: "+temp.authorityS+" SALSA-Hub: "+temp.hubS);
         }
         current = temp;
         return shouldPrefetch;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityNode.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityNode.java
@@ -17,6 +17,7 @@ import nl.vu.cs.s2group.nappa.room.data.ActivityExtraData;
 import nl.vu.cs.s2group.nappa.room.data.SessionData;
 
 public class ActivityNode {
+    private final static String LOG_TAG = ActivityNode.class.getSimpleName();
 
     public String activityName;
 
@@ -104,9 +105,9 @@ public class ActivityNode {
     public void setListSessionAggregateLiveData(LiveData<List<SessionDao.SessionAggregate>> listSessionAggregateLiveData) {
         this.listSessionAggregateLiveData = listSessionAggregateLiveData;
         this.listSessionAggregateLiveData.observeForever((list) -> {
-            Log.d("UPDATE SESSION", "source = "+activityName);
+            Log.d(LOG_TAG, "UPDATE SESSION " + "source = "+activityName);
             for (SessionDao.SessionAggregate listElem : list) {
-                Log.d("UPDATE SESSION", "dest: "+listElem.actName + ", count: " + listElem.countSource2Dest);
+                Log.d(LOG_TAG, "UPDATE SESSION " + "dest: "+listElem.actName + ", count: " + listElem.countSource2Dest);
             }
         });
     }
@@ -114,9 +115,9 @@ public class ActivityNode {
     public void setLastNListSessionAggregateLiveData(LiveData<List<SessionDao.SessionAggregate>> listLastNSessionAggregateLiveData) {
         this.listLastNSessionAggregateLiveData = listLastNSessionAggregateLiveData;
         this.listLastNSessionAggregateLiveData.observeForever((list) -> {
-            Log.d("UPDATED LAST N SESSION ", "source = "+activityName);
+            Log.d(LOG_TAG, "UPDATED LAST N SESSION " + "source = "+activityName);
             for (SessionDao.SessionAggregate listElem : list) {
-                Log.d("UPDATED  LAST N SESSION", "dest: "+listElem.actName + ", count: " + listElem.countSource2Dest);
+                Log.d(LOG_TAG, "UPDATED  LAST N SESSION " + "dest: "+listElem.actName + ", count: " + listElem.countSource2Dest);
             }
         });
     }
@@ -132,9 +133,9 @@ public class ActivityNode {
         this.listActivityExtraLiveData = listActivityExtraLiveData;
         //TODO update here
         this.listActivityExtraLiveData.observeForever((list) -> {
-            Log.d("PREFSTRAT2", activityName);
+            Log.d(LOG_TAG, "PREFSTRAT2 " + activityName);
             for (ActivityExtraData listElem : list) {
-                Log.d("PREFSTRAT2", "actid: "+listElem.idActivity+ ", key: " + listElem.key);
+                Log.d(LOG_TAG, "PREFSTRAT2 " + "actid: "+listElem.idActivity+ ", key: " + listElem.key);
             }
         });
     }
@@ -201,7 +202,7 @@ public class ActivityNode {
                 successors.put(activityNode, 1);
                 activityNode.ancestors.put(this, 1);
                 //CREATE NEW SESSIONDATA - THIS IS THE FIRST TIME
-                Log.w("ACTNODE", "CREATING, NOT IN DB");
+                Log.d(LOG_TAG, "ACTNODE " + "CREATING, NOT IN DB");
                 PrefetchingLib.addSessionData(activityName, activityNode.activityName, 1L);
                 return true;
             }
@@ -213,12 +214,12 @@ public class ActivityNode {
                 //UPDATE SESSIONDATA - THE SESSIONDATA ALREADY EXISTS
                 /*if ( successors.get(activityNode) > 0 ) {
                     PrefetchingLib.updateSessionData(activityName, activityNode.activityName, successors.get(activityNode).longValue());
-                    Log.w("ACTNODE", "CREATING, NOT IN DB");
+                    Log.d("ACTNODE", "CREATING, NOT IN DB");
                 } else {
-                    Log.w("ACTNODE", "UPDATING AFTER LOADING FROM DB");
+                    Log.d("ACTNODE", "UPDATING AFTER LOADING FROM DB");
                     PrefetchingLib.addSessionData(activityName, activityNode.activityName, 1L);
                 }*/
-                Log.w("ACTNODE", "UPDATING AFTER LOADING FROM DB");
+                Log.d(LOG_TAG, "ACTNODE " + "UPDATING AFTER LOADING FROM DB");
                 PrefetchingLib.updateSessionData(activityName, activityNode.activityName, successors.get(activityNode).longValue());
                 return true;
             }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityNode.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityNode.java
@@ -214,9 +214,9 @@ public class ActivityNode {
                 //UPDATE SESSIONDATA - THE SESSIONDATA ALREADY EXISTS
                 /*if ( successors.get(activityNode) > 0 ) {
                     PrefetchingLib.updateSessionData(activityName, activityNode.activityName, successors.get(activityNode).longValue());
-                    Log.d("ACTNODE", "CREATING, NOT IN DB");
+                    Log.w("ACTNODE", "CREATING, NOT IN DB");
                 } else {
-                    Log.d("ACTNODE", "UPDATING AFTER LOADING FROM DB");
+                    Log.w("ACTNODE", "UPDATING AFTER LOADING FROM DB");
                     PrefetchingLib.addSessionData(activityName, activityNode.activityName, 1L);
                 }*/
                 Log.d(LOG_TAG, "ACTNODE " + "UPDATING AFTER LOADING FROM DB");

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl.java
@@ -16,23 +16,23 @@ public class PrefetchStrategyImpl implements PrefetchStrategy {
     @NonNull
     @Override
     public List<String> getTopNUrlToPrefetchForNode(ActivityNode node, Integer maxNumber) {
-        Log.w("PrefStratImpl", "Started for node: "+node.activityName);
+        Log.d("PrefStratImpl", "Started for node: "+node.activityName);
         SessionDao.SessionAggregate best = null;
         List<SessionDao.SessionAggregate> sessionAggregateList = node.getSessionAggregateList();
         if (sessionAggregateList!=null) {
             for (SessionDao.SessionAggregate aggregate : sessionAggregateList) {
-                Log.w("PrefStratImpl", "Evaluating successor: " + aggregate.actName);
+                Log.d("PrefStratImpl", "Evaluating successor: " + aggregate.actName);
                 if (best == null) {
                     best = aggregate;
                 } else if (aggregate.countSource2Dest > best.countSource2Dest) {
-                    Log.w("PrefStratImpl",
+                    Log.d("PrefStratImpl",
                             "choosing "+aggregate.actName+": "+aggregate.countSource2Dest+" against " +
                                     best.actName+": "+best.countSource2Dest);
                     best = aggregate;
                 }
             }
             if (best != null) {
-                Log.w("PrefStratImpl", "Chosen successor: " + best.actName);
+                Log.d("PrefStratImpl", "Chosen successor: " + best.actName);
                 List<AggregateUrlDao.AggregateURL> list = PrefetchingDatabase.getInstance().urlDao().getAggregateForIdActivity(best.idActDest, maxNumber);
                 LinkedList<String> toBeReturned = new LinkedList<String>();
                 for (AggregateUrlDao.AggregateURL elem : list) {
@@ -40,10 +40,10 @@ public class PrefetchStrategyImpl implements PrefetchStrategy {
                 }
                 return toBeReturned;
             } else {
-                Log.w("PrefStratImpl", "Null successor");
+                Log.d("PrefStratImpl", "Null successor");
             }
         } else {
-            Log.w("PrefStratImpl", "SessionAggregateList is null");
+            Log.d("PrefStratImpl", "SessionAggregateList is null");
         }
         return Arrays.asList(new String[]{});
     }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl2.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl2.java
@@ -25,23 +25,23 @@ public class PrefetchStrategyImpl2 implements PrefetchStrategy {
     @NonNull
     @Override
     public List<String> getTopNUrlToPrefetchForNode(ActivityNode node, Integer maxNumber) {
-        /*Log.d("PrefStratImpl", "Started for node: "+node.activityName);
+        /*Log.w("PrefStratImpl", "Started for node: "+node.activityName);
         SessionDao.SessionAggregate best = null;
         List<SessionDao.SessionAggregate> sessionAggregateList = node.getSessionAggregateList();
         if (sessionAggregateList!=null) {
             for (SessionDao.SessionAggregate aggregate : sessionAggregateList) {
-                Log.d("PrefStratImpl", "Evaluating successor: " + aggregate.actName);
+                Log.w("PrefStratImpl", "Evaluating successor: " + aggregate.actName);
                 if (best == null) {
                     best = aggregate;
                 } else if (aggregate.countSource2Dest > best.countSource2Dest) {
-                    Log.d("PrefStratImpl",
+                    Log.w("PrefStratImpl",
                             "choosing "+aggregate.actName+": "+aggregate.countSource2Dest+" against " +
                                     best.actName+": "+best.countSource2Dest);
                     best = aggregate;
                 }
             }
             if (best != null) {
-                Log.d("PrefStratImpl", "Chosen successor: " + best.actName);
+                Log.w("PrefStratImpl", "Chosen successor: " + best.actName);
                 List<AggregateUrlDao.AggregateURL> list = PrefetchingDatabase.getInstance().urlDao().getAggregateForIdActivity(best.idActDest, maxNumber);
                 LinkedList<String> toBeReturned = new LinkedList<String>();
                 for (AggregateUrlDao.AggregateURL elem : list) {
@@ -49,26 +49,26 @@ public class PrefetchStrategyImpl2 implements PrefetchStrategy {
                 }
                 return toBeReturned;
             } else {
-                Log.d("PrefStratImpl", "Null successor");
+                Log.w("PrefStratImpl", "Null successor");
             }
         } else {
-            Log.d("PrefStratImpl", "SessionAggregateList is null");
+            Log.w("PrefStratImpl", "SessionAggregateList is null");
         }*/
         //new Thread(() -> {
             List<ActivityExtraData> extraDataList = node.getListActivityExtraLiveData().getValue();
             if (extraDataList != null) {
                 /*for (ActivityExtraData data : extraDataList) {
-                    Log.d(LOG_TAG, "actId: " + data.idActivity + "\t" + data.key + ": " + data.value);
+                    Log.w("PREFSTRAT2", "actId: " + data.idActivity + "\t" + data.key + ": " + data.value);
 
                     LinkedList<DiffMatchPatch.Diff> list = dmp.diffMain(data.value,
                             "http://api.openweathermap.org/data/2.5/weather?q=Kabul&appid=75f4ddb403cdbac1df21fa8a10c21ce9");
                     dmp.diffCleanupEfficiency(list);
 
                     for (DiffMatchPatch.Diff diff : list) {
-                        Log.d(LOG_TAG, diff.toString());
+                        Log.w("PREFSTRAT2", diff.toString());
                     }
 
-                    Log.d(LOG_TAG, "----------------");
+                    Log.w("PREFSTRAT2", "----------------");
                 }*/
                 Map<ActivityNode, Integer> successors = node.getSuccessors();
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl2.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl2.java
@@ -18,29 +18,30 @@ import nl.vu.cs.s2group.nappa.room.PrefetchingDatabase;
 import nl.vu.cs.s2group.nappa.room.data.ActivityExtraData;
 
 public class PrefetchStrategyImpl2 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl2.class.getSimpleName();
 
     private DiffMatchPatch dmp = new DiffMatchPatch();
 
     @NonNull
     @Override
     public List<String> getTopNUrlToPrefetchForNode(ActivityNode node, Integer maxNumber) {
-        /*Log.w("PrefStratImpl", "Started for node: "+node.activityName);
+        /*Log.d("PrefStratImpl", "Started for node: "+node.activityName);
         SessionDao.SessionAggregate best = null;
         List<SessionDao.SessionAggregate> sessionAggregateList = node.getSessionAggregateList();
         if (sessionAggregateList!=null) {
             for (SessionDao.SessionAggregate aggregate : sessionAggregateList) {
-                Log.w("PrefStratImpl", "Evaluating successor: " + aggregate.actName);
+                Log.d("PrefStratImpl", "Evaluating successor: " + aggregate.actName);
                 if (best == null) {
                     best = aggregate;
                 } else if (aggregate.countSource2Dest > best.countSource2Dest) {
-                    Log.w("PrefStratImpl",
+                    Log.d("PrefStratImpl",
                             "choosing "+aggregate.actName+": "+aggregate.countSource2Dest+" against " +
                                     best.actName+": "+best.countSource2Dest);
                     best = aggregate;
                 }
             }
             if (best != null) {
-                Log.w("PrefStratImpl", "Chosen successor: " + best.actName);
+                Log.d("PrefStratImpl", "Chosen successor: " + best.actName);
                 List<AggregateUrlDao.AggregateURL> list = PrefetchingDatabase.getInstance().urlDao().getAggregateForIdActivity(best.idActDest, maxNumber);
                 LinkedList<String> toBeReturned = new LinkedList<String>();
                 for (AggregateUrlDao.AggregateURL elem : list) {
@@ -48,26 +49,26 @@ public class PrefetchStrategyImpl2 implements PrefetchStrategy {
                 }
                 return toBeReturned;
             } else {
-                Log.w("PrefStratImpl", "Null successor");
+                Log.d("PrefStratImpl", "Null successor");
             }
         } else {
-            Log.w("PrefStratImpl", "SessionAggregateList is null");
+            Log.d("PrefStratImpl", "SessionAggregateList is null");
         }*/
         //new Thread(() -> {
             List<ActivityExtraData> extraDataList = node.getListActivityExtraLiveData().getValue();
             if (extraDataList != null) {
                 /*for (ActivityExtraData data : extraDataList) {
-                    Log.w("PREFSTRAT2", "actId: " + data.idActivity + "\t" + data.key + ": " + data.value);
+                    Log.d(LOG_TAG, "actId: " + data.idActivity + "\t" + data.key + ": " + data.value);
 
                     LinkedList<DiffMatchPatch.Diff> list = dmp.diffMain(data.value,
                             "http://api.openweathermap.org/data/2.5/weather?q=Kabul&appid=75f4ddb403cdbac1df21fa8a10c21ce9");
                     dmp.diffCleanupEfficiency(list);
 
                     for (DiffMatchPatch.Diff diff : list) {
-                        Log.w("PREFSTRAT2", diff.toString());
+                        Log.d(LOG_TAG, diff.toString());
                     }
 
-                    Log.w("PREFSTRAT2", "----------------");
+                    Log.d(LOG_TAG, "----------------");
                 }*/
                 Map<ActivityNode, Integer> successors = node.getSuccessors();
 
@@ -124,8 +125,8 @@ public class PrefetchStrategyImpl2 implements PrefetchStrategy {
 
                     List<String> candidates = new LinkedList<>();
 
-                    Log.w("PREFSTRAT2", PrefetchingLib.getExtrasMap().toString());
-                    Log.w("PREFSTRAT2",  PrefetchingLib.getActivityIdFromName(node.activityName).toString());
+                    Log.d(LOG_TAG, PrefetchingLib.getExtrasMap().toString());
+                    Log.d(LOG_TAG,  PrefetchingLib.getActivityIdFromName(node.activityName).toString());
 
                     for (ParameteredUrl url : parameteredUrls) {
                         //for (ActivityExtraData activityExtraData: extraDataList) {
@@ -150,7 +151,7 @@ public class PrefetchStrategyImpl2 implements PrefetchStrategy {
 
 
                     for (String candidate: candidates) {
-                        Log.e("PREFSTRAT2", candidate);
+                        Log.d(LOG_TAG, candidate);
                     }
 
                     return candidates;
@@ -162,7 +163,7 @@ public class PrefetchStrategyImpl2 implements PrefetchStrategy {
 
                 }
             } else {
-                Log.e("PREFSTRAT2", "NO EXTRADATA");
+                Log.d(LOG_TAG, "NO EXTRADATA");
             }
         //}).start();
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl3.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl3.java
@@ -14,6 +14,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl3 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl3.class.getSimpleName();
 
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
@@ -91,7 +92,7 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
                 }
 
             }
-            Log.e("PREFSTRAT3", "Computed probability: " + prob + " for " + node1.activityName);
+            Log.d(LOG_TAG, "Computed probability: " + prob + " for " + node1.activityName);
         }
 
 
@@ -103,7 +104,7 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
 
         for (ActivityNode succ : successorCountMap.keySet()) {
             float prob = initialProbability * (successorCountMap.get(succ)/total);
-            Log.e("PREFSTRAT3", "Computed probability: " + prob);
+            Log.d(LOG_TAG, "Computed probability: " + prob);
             if (prob >= threshold) {
                 if (!probableNodes.contains(succ)) {
                     probableNodes.add(succ);
@@ -143,7 +144,7 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
         }
 
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT3", candidate);
+            Log.d(LOG_TAG, candidate);
         }
 
         return candidates;
@@ -171,8 +172,8 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
 
             for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
 
-                //for(String k: extrasMap.keySet())Log.e("PREFSTRAT5In",k);
-                //Log.e("PREFSTRAT5In",extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())+"");
+                //for(String k: extrasMap.keySet())Log.d("PREFSTRAT5In",k);
+                //Log.d("PREFSTRAT5In",extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())+"");
                 //BUG -- 1 crash if extrasMap is null
                 if ((null != extrasMap) && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
                     candidates.add(
@@ -183,7 +184,7 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
         //}
 
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT3", candidate + " for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
         }
 
         return candidates;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl3.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl3.java
@@ -104,7 +104,7 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
 
         for (ActivityNode succ : successorCountMap.keySet()) {
             float prob = initialProbability * (successorCountMap.get(succ)/total);
-            Log.d(LOG_TAG, "Computed probability: " + prob);
+            Log.e("PREFSTRAT3", "Computed probability: " + prob);
             if (prob >= threshold) {
                 if (!probableNodes.contains(succ)) {
                     probableNodes.add(succ);
@@ -144,7 +144,7 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
         }
 
         for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate);
+            Log.e("PREFSTRAT3", candidate);
         }
 
         return candidates;
@@ -172,8 +172,8 @@ public class PrefetchStrategyImpl3 implements PrefetchStrategy {
 
             for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
 
-                //for(String k: extrasMap.keySet())Log.d("PREFSTRAT5In",k);
-                //Log.d("PREFSTRAT5In",extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())+"");
+                //for(String k: extrasMap.keySet())Log.e("PREFSTRAT5In",k);
+                //Log.e("PREFSTRAT5In",extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())+"");
                 //BUG -- 1 crash if extrasMap is null
                 if ((null != extrasMap) && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
                     candidates.add(

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl4.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl4.java
@@ -15,6 +15,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl4 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl4.class.getSimpleName();
 
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
@@ -50,7 +51,7 @@ public class PrefetchStrategyImpl4 implements PrefetchStrategy {
 
         for (int i=0; i<maxNumber; i++) {
             listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-            Log.e("PREFSTRAT9","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
+            Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }
         //return computeCandidateUrl(node);
@@ -78,7 +79,7 @@ public class PrefetchStrategyImpl4 implements PrefetchStrategy {
         int total = 0;
         for(Long candidate : successorCountMap.keySet()) {
             total+=successorCountMap.get(candidate);
-            Log.d("PREFSTRAT4","actName :"+reversedHashMap.get(candidate)+" hit: "+successorCountMap.get(candidate));
+            Log.d(LOG_TAG,"actName :"+reversedHashMap.get(candidate)+" hit: "+successorCountMap.get(candidate));
         }
         //////////////////////////// Will calculate the probability to access a node by partial match based on a 0-order markov-model
         //////////////////////////// https://pdfs.semanticscholar.org/f9dc/bf7b0c900335932d9a651b9c21d8a59c3679.pdf
@@ -89,7 +90,7 @@ public class PrefetchStrategyImpl4 implements PrefetchStrategy {
             ActivityNode node1 = PrefetchingLib.getActivityGraph().getByName(reversedHashMap.get(succ));
             node1.prob=prob;
             probableNodes.add(node1);
-            Log.e("PREFSTRAT4", "Computed probability: " + prob + " for " + node1.activityName);
+            Log.d(LOG_TAG, "Computed probability: " + prob + " for " + node1.activityName);
         }
         return probableNodes;
     }
@@ -127,7 +128,7 @@ public class PrefetchStrategyImpl4 implements PrefetchStrategy {
         //}
 
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT4", candidate + " for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
         }
 
         return candidates;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl5.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl5.java
@@ -58,7 +58,7 @@ public class PrefetchStrategyImpl5 implements PrefetchStrategy {
         for (int i=0; i<probableNodes.size(); i++) {
             if(probableNodes.get(i).pageRank>n) {
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).pageRank);
+                Log.e("PREFSTRAT5", "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).pageRank);
             }
         }*/
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl5.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl5.java
@@ -14,6 +14,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl5 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl5.class.getSimpleName();
 
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
     float threshold;
@@ -51,13 +52,13 @@ public class PrefetchStrategyImpl5 implements PrefetchStrategy {
 
         for (int i=0; i<maxNumber; i++) {
             listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-            Log.e("PREFSTRAT5","SELECTED --> " + probableNodes.get(i).activityName+ " index: " + probableNodes.get(i).pageRank);
+            Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName+ " index: " + probableNodes.get(i).pageRank);
         }
         /*float n = 0.25f/(float)reversedHashMap.keySet().size();
         for (int i=0; i<probableNodes.size(); i++) {
             if(probableNodes.get(i).pageRank>n) {
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.e("PREFSTRAT5", "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).pageRank);
+                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).pageRank);
             }
         }*/
 
@@ -115,7 +116,7 @@ public class PrefetchStrategyImpl5 implements PrefetchStrategy {
 
         }
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT5", candidate + " url for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " url for: " + toBeChecked.activityName);
         }
         return candidates;
     }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl6.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl6.java
@@ -14,6 +14,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl6 implements PrefetchStrategy{
+    private final static String LOG_TAG = PrefetchStrategyImpl6.class.getSimpleName();
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
     float threshold;
 
@@ -51,7 +52,7 @@ public class PrefetchStrategyImpl6 implements PrefetchStrategy{
 
         for (int i=0; i<maxNumber; i++) {
             listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-            Log.e("PREFSTRAT6","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
+            Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
 
         }
 
@@ -59,7 +60,7 @@ public class PrefetchStrategyImpl6 implements PrefetchStrategy{
         for (int i=0; i<probableNodes.size(); i++) {
             if(probableNodes.get(i).authority>n) {
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.e("PREFSTRAT6", "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
+                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
             }
         }*/
 
@@ -117,7 +118,7 @@ public class PrefetchStrategyImpl6 implements PrefetchStrategy{
 
         }
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT6", candidate + " url for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " url for: " + toBeChecked.activityName);
         }
         return candidates;
     }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl6.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl6.java
@@ -60,7 +60,7 @@ public class PrefetchStrategyImpl6 implements PrefetchStrategy{
         for (int i=0; i<probableNodes.size(); i++) {
             if(probableNodes.get(i).authority>n) {
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
+                Log.e("PREFSTRAT6", "SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
             }
         }*/
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl7.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl7.java
@@ -66,12 +66,12 @@ public class PrefetchStrategyImpl7 implements PrefetchStrategy {
         for (int i=0; i<probableNodes.size(); i++) {
             if(probableNodes.get(i).authorityS>n) {
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
-                Log.d(LOG_TAG, probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
+                Log.e("PREFSTRAT7", "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
+                Log.e("PREFSTRAT7", probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
             }else if(probableNodes.get(i).authorityS==n&&probableNodes.get(i).hubS>n){
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
-                Log.d(LOG_TAG, probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
+                Log.e("PREFSTRAT7", "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
+                Log.e("PREFSTRAT7", probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
             }
         }*/
         return listUrlToPrefetch;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl7.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl7.java
@@ -14,6 +14,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl7 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl7.class.getSimpleName();
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
     private float threshold;
 
@@ -57,7 +58,7 @@ public class PrefetchStrategyImpl7 implements PrefetchStrategy {
 
         for (int i=0; i<maxNumber; i++) {
             listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-            Log.e("PREFSTRAT7","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authorityS);
+            Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authorityS);
 
         }
 
@@ -65,12 +66,12 @@ public class PrefetchStrategyImpl7 implements PrefetchStrategy {
         for (int i=0; i<probableNodes.size(); i++) {
             if(probableNodes.get(i).authorityS>n) {
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.e("PREFSTRAT7", "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
-                Log.e("PREFSTRAT7", probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
+                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
+                Log.d(LOG_TAG, probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
             }else if(probableNodes.get(i).authorityS==n&&probableNodes.get(i).hubS>n){
                 listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-                Log.e("PREFSTRAT7", "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
-                Log.e("PREFSTRAT7", probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
+                Log.d(LOG_TAG, "SELECTED --> " + probableNodes.get(i).activityName + " index Auth: " + probableNodes.get(i).authorityS+ " index Hub: " + probableNodes.get(i).hubS);
+                Log.d(LOG_TAG, probableNodes.get(i).authorityS-probableNodes.get(i).hubS +"");
             }
         }*/
         return listUrlToPrefetch;
@@ -127,7 +128,7 @@ public class PrefetchStrategyImpl7 implements PrefetchStrategy {
 
         }
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT7", candidate + " url for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " url for: " + toBeChecked.activityName);
         }
         return candidates;
     }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl8.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl8.java
@@ -108,7 +108,7 @@ public class PrefetchStrategyImpl8 implements PrefetchStrategy {
                 }
 
             //}
-            //Log.d(LOG_TAG, "Computed probability: " + node1.prob + " for " + node1.activityName+ " s - "+threshold
+            //Log.e("PREFSTRAT8", "Computed probability: " + node1.prob + " for " + node1.activityName+ " s - "+threshold
                     //+" pr: " +node1.pageRank);
         }
         return probableNodes;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl8.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl8.java
@@ -14,6 +14,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl8 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl8.class.getSimpleName();
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
 
@@ -50,7 +51,7 @@ public class PrefetchStrategyImpl8 implements PrefetchStrategy {
 
         for (int i=0; i<maxNumber; i++) {
             listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-            Log.e("PREFSTRAT8","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
+            Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }
 
@@ -107,7 +108,7 @@ public class PrefetchStrategyImpl8 implements PrefetchStrategy {
                 }
 
             //}
-            //Log.e("PREFSTRAT8", "Computed probability: " + node1.prob + " for " + node1.activityName+ " s - "+threshold
+            //Log.d(LOG_TAG, "Computed probability: " + node1.prob + " for " + node1.activityName+ " s - "+threshold
                     //+" pr: " +node1.pageRank);
         }
         return probableNodes;
@@ -131,7 +132,7 @@ public class PrefetchStrategyImpl8 implements PrefetchStrategy {
         
 
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT8", candidate + " for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
         }
 
         return candidates;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl9.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl9.java
@@ -14,7 +14,7 @@
 
         for (int i=0; i<maxNumber; i++) {
         listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-        Log.e("PREFSTRAT9","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
+        Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }*/
 
@@ -35,6 +35,7 @@ import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
 
 public class PrefetchStrategyImpl9 implements PrefetchStrategy {
+    private final static String LOG_TAG = PrefetchStrategyImpl9.class.getSimpleName();
 
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
@@ -71,7 +72,7 @@ public class PrefetchStrategyImpl9 implements PrefetchStrategy {
 
         for (int i=0; i<maxNumber; i++) {
             listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-            Log.e("PREFSTRAT9","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
+            Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }
 
@@ -100,7 +101,7 @@ public class PrefetchStrategyImpl9 implements PrefetchStrategy {
         int total = 0;
         for(Long candidate : successorCountMap.keySet()) {
             total+=successorCountMap.get(candidate);
-            Log.d("PREFSTRAT9","actName :"+reversedHashMap.get(candidate)+" hit: "+successorCountMap.get(candidate));
+            Log.d(LOG_TAG,"actName :"+reversedHashMap.get(candidate)+" hit: "+successorCountMap.get(candidate));
         }
         //////////////////////////// Will calculate the probability to access a node by partial match based on a 0-order markov-model
         //////////////////////////// https://pdfs.semanticscholar.org/f9dc/bf7b0c900335932d9a651b9c21d8a59c3679.pdf
@@ -111,7 +112,7 @@ public class PrefetchStrategyImpl9 implements PrefetchStrategy {
             ActivityNode node1 = PrefetchingLib.getActivityGraph().getByName(reversedHashMap.get(succ));
             node1.prob=prob;
             probableNodes.add(node1);
-            Log.e("PREFSTRAT9", "Computed probability: " + prob + " for " + node1.activityName);
+            Log.d(LOG_TAG, "Computed probability: " + prob + " for " + node1.activityName);
         }
         return probableNodes;
     }
@@ -148,7 +149,7 @@ public class PrefetchStrategyImpl9 implements PrefetchStrategy {
         //}
 
         for (String candidate: candidates) {
-            Log.e("PREFSTRAT9", candidate + " for: " + toBeChecked.activityName);
+            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
         }
 
         return candidates;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl9.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchStrategyImpl9.java
@@ -14,7 +14,7 @@
 
         for (int i=0; i<maxNumber; i++) {
         listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
-        Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
+        Log.e("PREFSTRAT9","SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }*/
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/room/dao/UrlCandidateDao.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/room/dao/UrlCandidateDao.java
@@ -73,7 +73,7 @@ public interface UrlCandidateDao {
         public static List<ParameteredUrl> getParameteredUrlList(List<UrlCandidateToUrlParameter> parameterList) {
             ArrayMap<Long, ParameteredUrl> parameteredUrlHashMap = new ArrayMap<>();
 
-            Log.e("PARAM", "COUNT: " + parameterList.size());
+            Log.d("PARAM", "COUNT: " + parameterList.size());
 
             // For each parameter in the parameter list,  build a parameteredUrl object and store it
             //  in the hashmap
@@ -85,12 +85,12 @@ public interface UrlCandidateDao {
                     parameteredUrlHashMap.put(parameter.id, parameteredUrl);
                 }
 
-                Log.e("PARAM", "ID_ACTIVITY: " + parameter.idActivity);
+                Log.d("PARAM", "ID_ACTIVITY: " + parameter.idActivity);
 
                 /*try {*/
-                    Log.e("PARAM", parameter.urlPiece);
-                    Log.e("PARAM", parameter.type+"");
-                    Log.e("PARAM", parameter.urlOrder+"");
+                    Log.d("PARAM", parameter.urlPiece);
+                    Log.d("PARAM", parameter.type+"");
+                    Log.d("PARAM", parameter.urlOrder+"");
                     parameteredUrl.addParameter(parameter.urlOrder,
                             ParameteredUrl.getTYPESFromId(parameter.type),
                             parameter.urlPiece);

--- a/Test-App/Weather-and-News-app/app/src/main/java/nl/vu/cs/s2group/nappa/sample/app/weather_and_news/NewsActivity.java
+++ b/Test-App/Weather-and-News-app/app/src/main/java/nl/vu/cs/s2group/nappa/sample/app/weather_and_news/NewsActivity.java
@@ -26,6 +26,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class NewsActivity extends AppCompatActivity {
+    private final static String LOG_TAG = NewsActivity.class.getSimpleName();
 
     private Gson gson = new Gson();
     private Handler handler;
@@ -75,7 +76,7 @@ public class NewsActivity extends AppCompatActivity {
             @Override
             public void onFailure(Call call, IOException e) {
                 e.printStackTrace();
-                Log.e("ERROR", e.getMessage());
+                Log.e(LOG_TAG, "ERROR " + e.getMessage());
             }
 
             @Override

--- a/Test-App/Weather-and-News-app/app/src/main/java/nl/vu/cs/s2group/nappa/sample/app/weather_and_news/WeatherActivity.java
+++ b/Test-App/Weather-and-News-app/app/src/main/java/nl/vu/cs/s2group/nappa/sample/app/weather_and_news/WeatherActivity.java
@@ -26,6 +26,7 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class WeatherActivity extends AppCompatActivity {
+    private final static String LOG_TAG = WeatherActivity.class.getSimpleName();
 
     private String city;
     private Gson gson;
@@ -80,7 +81,7 @@ public class WeatherActivity extends AppCompatActivity {
             @Override
             public void onResponse(Call call, Response response) throws IOException {
                 Long end = new Date().getTime();
-                Log.d("PERF_REQUEST", (end-start)+" ms");
+                Log.d(LOG_TAG, "PERF_REQUEST " + (end-start)+" ms");
                 Weather weather = gson.fromJson(response.body().charStream(), Weather.class);
                 handler.post(() -> {
                     try {


### PR DESCRIPTION
Using the logs and checking the LogCat is currently messy since there is little to no pattern to logging tags. 

Changes:

* Use the debug log only
* Define a `LOG_TAG` constant per class with the class name
* Use the `LOG_TAG` constant as the tag for all logging calls.

Projects:

* Prefetching Library
* Test app

Issue: S2-group/NAPPA#36