### PR TITLE
Create a utility library to extract common/duplicated code from other classes

### DIFF
--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -10,8 +11,8 @@ import java.util.Map;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * This strategy greedily determine which activity successors can benefit the most from
@@ -53,12 +54,7 @@ public class GreedyPrefetchingStrategy implements PrefetchingStrategy {
 
         List<ActivityNode> probableNodes = getMostProbableNodes(node, 1, new LinkedList<>());
 
-        List<String> listUrlToPrefetch = new LinkedList<>();
-        for (ActivityNode node1 : probableNodes) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(node1, node));
-        }
-
-        return listUrlToPrefetch;
+        return NappaUtil.getUrlsFromCandidateNodes(node, probableNodes);
     }
 
     /**
@@ -109,28 +105,5 @@ public class GreedyPrefetchingStrategy implements PrefetchingStrategy {
         }
 
         return probableNodes;
-    }
-
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-
-        List<String> candidates = new LinkedList<>();
-
-        // Get all extras for the current activity
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-
-            for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-                if ((null != extrasMap) && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                    candidates.add(
-                            parameteredUrl.fillParams(extrasMap)
-                    );
-                }
-            }
-
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
-        }
-
-        return candidates;
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategy.java
@@ -34,7 +34,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  * of node candidates generated, a threshold value is inserted.
  */
 public class GreedyPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = GreedyPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = GreedyPrefetchingStrategy.class.getSimpleName();
 
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyWithPageRankScoresPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyWithPageRankScoresPrefetchingStrategy.java
@@ -21,7 +21,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  */
 @Deprecated
 public class GreedyWithPageRankScoresPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = GreedyWithPageRankScoresPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = GreedyWithPageRankScoresPrefetchingStrategy.class.getSimpleName();
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyWithPageRankScoresPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyWithPageRankScoresPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -10,8 +11,8 @@ import java.util.Map;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * This strategy is based in the {@link GreedyPrefetchingStrategy}, where the score
@@ -56,7 +57,7 @@ public class GreedyWithPageRankScoresPrefetchingStrategy implements PrefetchingS
         maxNumber = (int) (threshold*probableNodes.size() +1);
 
         for (int i=0; i<maxNumber; i++) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
+            listUrlToPrefetch.addAll(NappaUtil.getUrlsFromCandidateNode(node, probableNodes.get(i)));
             Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }
@@ -110,29 +111,5 @@ public class GreedyWithPageRankScoresPrefetchingStrategy implements PrefetchingS
                 }
         }
         return probableNodes;
-    }
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-
-        List<String> candidates = new LinkedList<>();
-
-
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-
-        for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-            
-            if ((null != extrasMap) && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                candidates.add(
-                        parameteredUrl.fillParams(extrasMap)
-                );
-            }
-        }
-        
-
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
-        }
-
-        return candidates;
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/HITSPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/HITSPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -10,8 +11,8 @@ import java.util.Map;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * This strategy utilizes the Hyperlink-Induced Topic Search (HITS) link analysis
@@ -58,7 +59,7 @@ public class HITSPrefetchingStrategy implements PrefetchingStrategy {
         maxNumber = (int) (threshold*probableNodes.size() +1);
 
         for (int i=0; i<maxNumber; i++) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
+            listUrlToPrefetch.addAll(NappaUtil.getUrlsFromCandidateNode(node, probableNodes.get(i)));
             Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authority);
 
         }
@@ -100,25 +101,5 @@ public class HITSPrefetchingStrategy implements PrefetchingStrategy {
         }
 
         return probableNodes;
-    }
-
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-
-        List<String> candidates = new LinkedList<>();
-
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-        for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-            if ((null != extrasMap) && !extrasMap.isEmpty() && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                candidates.add(
-                        parameteredUrl.fillParams(extrasMap)
-                );
-            }
-
-        }
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " url for: " + toBeChecked.activityName);
-        }
-        return candidates;
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/HITSPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/HITSPrefetchingStrategy.java
@@ -26,7 +26,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  */
 @Deprecated
 public class HITSPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = HITSPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = HITSPrefetchingStrategy.class.getSimpleName();
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
     float threshold;
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/MostVisitedSuccessorPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/MostVisitedSuccessorPrefetchingStrategy.java
@@ -18,7 +18,7 @@ import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
  */
 @Deprecated
 public class MostVisitedSuccessorPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = MostVisitedSuccessorPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = MostVisitedSuccessorPrefetchingStrategy.class.getSimpleName();
     @NonNull
     @Override
     public List<String> getTopNUrlToPrefetchForNode(ActivityNode node, Integer maxNumber) {

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMPrefetchingStrategy.java
@@ -27,7 +27,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  */
 @Deprecated
 public class PPMPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = PPMPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = PPMPrefetchingStrategy.class.getSimpleName();
 
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -11,8 +12,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * Utilizes the Prediction by Partial Match (PPM) based on a 0-order markov-model.
@@ -61,7 +62,7 @@ public class PPMPrefetchingStrategy implements PrefetchingStrategy {
         maxNumber = (int) (threshold*probableNodes.size() +1);
 
         for (int i=0; i<maxNumber; i++) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
+            listUrlToPrefetch.addAll(NappaUtil.getUrlsFromCandidateNode(node, probableNodes.get(i)));
             Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }
@@ -115,28 +116,5 @@ public class PPMPrefetchingStrategy implements PrefetchingStrategy {
             else {successorCountMap.put(succ.idActDest, succ.countSource2Dest.intValue()); }//Log.d("PREFSTRAT4 insert count",succ.countSource2Dest+"");}
         }
         return  successorCountMap;
-    }
-
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-
-        List<String> candidates = new LinkedList<>();
-
-
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-
-        for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-            if (extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                candidates.add(
-                        parameteredUrl.fillParams(extrasMap)
-                );
-            }
-        }
-
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
-        }
-
-        return candidates;
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMWithHITSScoresPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMWithHITSScoresPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -11,8 +12,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * This strategy is based in the {@link PPMPrefetchingStrategy}, where the score
@@ -57,7 +58,7 @@ public class PPMWithHITSScoresPrefetchingStrategy implements PrefetchingStrategy
         maxNumber = (int) (threshold*probableNodes.size() +1);
 
         for (int i=0; i<maxNumber; i++) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
+            listUrlToPrefetch.addAll(NappaUtil.getUrlsFromCandidateNode(node, probableNodes.get(i)));
             Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).prob);
 
         }
@@ -112,27 +113,5 @@ public class PPMWithHITSScoresPrefetchingStrategy implements PrefetchingStrategy
             else {successorCountMap.put(succ.idActDest, succ.countSource2Dest.intValue()); }//Log.d("PREFSTRAT9 insert count",succ.countSource2Dest+"");}
         }
         return  successorCountMap;
-    }
-
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-        List<String> candidates = new LinkedList<>();
-
-
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-
-        for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-            if (extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                candidates.add(
-                        parameteredUrl.fillParams(extrasMap)
-                );
-            }
-        }
-
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " for: " + toBeChecked.activityName);
-        }
-
-        return candidates;
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMWithHITSScoresPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PPMWithHITSScoresPrefetchingStrategy.java
@@ -22,7 +22,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  */
 @Deprecated
 public class PPMWithHITSScoresPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = PPMWithHITSScoresPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = PPMWithHITSScoresPrefetchingStrategy.class.getSimpleName();
 
     private float threshold;
     private HashMap<Long, String> reversedHashMap = new HashMap<>();

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PageRankPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PageRankPrefetchingStrategy.java
@@ -21,7 +21,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  */
 @Deprecated
 public class PageRankPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = PageRankPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = PageRankPrefetchingStrategy.class.getSimpleName();
 
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
     float threshold;

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PageRankPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PageRankPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -10,8 +11,8 @@ import java.util.Map;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * This strategy utilizes the PageRank link analysis algorithm to determine which
@@ -53,7 +54,7 @@ public class PageRankPrefetchingStrategy implements PrefetchingStrategy {
         maxNumber = (int) (threshold*probableNodes.size() +1);
 
         for (int i=0; i<maxNumber; i++) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
+            listUrlToPrefetch.addAll(NappaUtil.getUrlsFromCandidateNode(node, probableNodes.get(i)));
             Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName+ " index: " + probableNodes.get(i).pageRank);
         }
 
@@ -96,24 +97,5 @@ public class PageRankPrefetchingStrategy implements PrefetchingStrategy {
         return probableNodes;
     }
 
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-
-        List<String> candidates = new LinkedList<>();
-
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-        for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-            if ((null != extrasMap) && !extrasMap.isEmpty() && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                candidates.add(
-                        parameteredUrl.fillParams(extrasMap)
-                );
-            }
-
-        }
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " url for: " + toBeChecked.activityName);
-        }
-        return candidates;
-    }
 }
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchingStrategyImpl2.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/PrefetchingStrategyImpl2.java
@@ -20,7 +20,7 @@ import nl.vu.cs.s2group.nappa.room.data.ActivityExtraData;
 // TODO: Read the strategy, provide a JavaDoc with basic description and update class name
 @Deprecated
 public class PrefetchingStrategyImpl2 implements PrefetchingStrategy {
-    private final static String LOG_TAG = PrefetchingStrategyImpl2.class.getSimpleName();
+    private static final String LOG_TAG = PrefetchingStrategyImpl2.class.getSimpleName();
 
     private DiffMatchPatch dmp = new DiffMatchPatch();
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/SALSAPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/SALSAPrefetchingStrategy.java
@@ -1,7 +1,8 @@
 package nl.vu.cs.s2group.nappa.prefetch;
 
-import androidx.annotation.NonNull;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -10,8 +11,8 @@ import java.util.Map;
 
 import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
-import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 import nl.vu.cs.s2group.nappa.room.dao.SessionDao;
+import nl.vu.cs.s2group.nappa.util.NappaUtil;
 
 /**
  * Utilizes the Stochastic Approach for Link-Structure Analysis (SALSA) ranking
@@ -63,7 +64,7 @@ public class SALSAPrefetchingStrategy implements PrefetchingStrategy {
         maxNumber = (int) (threshold*probableNodes.size() + 1);
 
         for (int i=0; i<maxNumber; i++) {
-            listUrlToPrefetch.addAll(computeCandidateUrl2(probableNodes.get(i), node));
+            listUrlToPrefetch.addAll(NappaUtil.getUrlsFromCandidateNode(node, probableNodes.get(i)));
             Log.d(LOG_TAG,"SELECTED --> " + probableNodes.get(i).activityName + " index: " + probableNodes.get(i).authorityS);
 
         }
@@ -105,25 +106,5 @@ public class SALSAPrefetchingStrategy implements PrefetchingStrategy {
         }
 
         return probableNodes;
-    }
-
-    private List<String> computeCandidateUrl2(ActivityNode toBeChecked, ActivityNode node) {
-        node.parameteredUrlMap.keySet();
-
-        List<String> candidates = new LinkedList<>();
-
-        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(PrefetchingLib.getActivityIdFromName(node.activityName));
-        for (ParameteredUrl parameteredUrl : toBeChecked.parameteredUrlList) {
-            if ((null != extrasMap) && !extrasMap.isEmpty() && extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
-                candidates.add(
-                        parameteredUrl.fillParams(extrasMap)
-                );
-            }
-
-        }
-        for (String candidate: candidates) {
-            Log.d(LOG_TAG, candidate + " url for: " + toBeChecked.activityName);
-        }
-        return candidates;
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/SALSAPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/SALSAPrefetchingStrategy.java
@@ -26,7 +26,7 @@ import nl.vu.cs.s2group.nappa.util.NappaUtil;
  */
 @Deprecated
 public class SALSAPrefetchingStrategy implements PrefetchingStrategy {
-    private final static String LOG_TAG = SALSAPrefetchingStrategy.class.getSimpleName();
+    private static final String LOG_TAG = SALSAPrefetchingStrategy.class.getSimpleName();
     private HashMap<Long, String> reversedHashMap = new HashMap<>();
     private float threshold;
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/util/NappaUtil.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/util/NappaUtil.java
@@ -1,0 +1,46 @@
+package nl.vu.cs.s2group.nappa.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import nl.vu.cs.s2group.nappa.PrefetchingLib;
+import nl.vu.cs.s2group.nappa.graph.ActivityNode;
+import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
+
+public class NappaUtil {
+    private NappaUtil() {
+        throw new IllegalStateException("NappaUtil is a utility class and should be instantiated!");
+    }
+
+    @NotNull
+    public static List<String> getUrlsFromCandidateNodes(ActivityNode visitedNode, @NotNull List<ActivityNode> candidateNodes) {
+        List<String> candidateUrls = new LinkedList<>();
+
+        for (ActivityNode candidateNode : candidateNodes) {
+            candidateUrls.addAll(getUrlsFromCandidateNode(visitedNode, candidateNode));
+        }
+
+        return candidateUrls;
+    }
+
+    @NotNull
+    public static List<String> getUrlsFromCandidateNode(@NotNull ActivityNode visitedNode, @NotNull ActivityNode candidateNode) {
+        List<String> candidateUrls = new LinkedList<>();
+        long activityId = PrefetchingLib.getActivityIdFromName(visitedNode.activityName);
+        Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(activityId);
+
+        if (extrasMap == null || extrasMap.isEmpty()) return candidateUrls;
+
+        for (ParameteredUrl parameteredUrl : candidateNode.parameteredUrlList) {
+            if (extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
+                String urlWithExtras = parameteredUrl.fillParams(extrasMap);
+                candidateUrls.add(urlWithExtras);
+            }
+        }
+
+        return candidateUrls;
+    }
+}

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/util/NappaUtil.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/util/NappaUtil.java
@@ -55,9 +55,11 @@ public class NappaUtil {
         long activityId = PrefetchingLib.getActivityIdFromName(visitedNode.activityName);
         Map<String, String> extrasMap = PrefetchingLib.getExtrasMap().get(activityId);
 
+        // Verifies if the current activity contain any registered extras in the current session
         if (extrasMap == null || extrasMap.isEmpty()) return candidateUrls;
 
         for (ParameteredUrl parameteredUrl : candidateNode.parameteredUrlList) {
+            // Verifies if the extras required by the candidate URL are known
             if (extrasMap.keySet().containsAll(parameteredUrl.getParamKeys())) {
                 String urlWithExtras = parameteredUrl.fillParams(extrasMap);
                 candidateUrls.add(urlWithExtras);

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/util/NappaUtil.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/util/NappaUtil.java
@@ -10,11 +10,25 @@ import nl.vu.cs.s2group.nappa.PrefetchingLib;
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
 import nl.vu.cs.s2group.nappa.prefetchurl.ParameteredUrl;
 
+/**
+ * This class containing common utility methods for the NAPPA Prefetching Library
+ */
 public class NappaUtil {
+
     private NappaUtil() {
         throw new IllegalStateException("NappaUtil is a utility class and should be instantiated!");
     }
 
+    /**
+     * Parses the list of candidate nodes and verifies if the URLs requested in a candidate node can
+     * be requested with the Extras captured in the visited node
+     *
+     * @param visitedNode    Represents the node which the user is currently visiting
+     * @param candidateNodes Represents a list containing all nodes with the potential to be visited
+     *                       in the near future
+     * @return All URLs requested by all candidate nodes that can be requested with the information
+     * present in the currently visited node
+     */
     @NotNull
     public static List<String> getUrlsFromCandidateNodes(ActivityNode visitedNode, @NotNull List<ActivityNode> candidateNodes) {
         List<String> candidateUrls = new LinkedList<>();
@@ -26,6 +40,15 @@ public class NappaUtil {
         return candidateUrls;
     }
 
+    /**
+     * Verifies if the URLs requested in the candidate node can be requested with the Extras captured
+     * in the visited node
+     *
+     * @param visitedNode   Represents the node which the user is currently visiting
+     * @param candidateNode Represents a node with the potential to be visited in the near future
+     * @return All URLs requested in the candidate node that can be requested with the information
+     * present in the currently visited node
+     */
     @NotNull
     public static List<String> getUrlsFromCandidateNode(@NotNull ActivityNode visitedNode, @NotNull ActivityNode candidateNode) {
         List<String> candidateUrls = new LinkedList<>();


### PR DESCRIPTION
Each prefetching strategy reimplements the same method to obtain the URLs to prefetch from a set of candidate nodes. This method can be extracted to a utility class. In preparation for future strategies, this PR performs this extraction.

While other pieces of code can be extracted to this utility class, for starter, extracting the creation of URLs is enough. Furthermore, this will keep this PR short and easy to review. Once the utility class is created in the master branch, we can implement each extraction in a dedicated branch.

Closes #50 