### PR TITLE
Fix plugin not instrument sample apps under the NAPPA package

### DIFF
--- a/Android-Studio-Plugin/build.gradle
+++ b/Android-Studio-Plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'nl.vu.cs.s2group.nappa.plugin'
-version '1.1.2'
+version '1.1.3'
 
 sourceCompatibility = 1.8
 

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/util/InstrumentUtil.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/util/InstrumentUtil.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
  */
 public final class InstrumentUtil {
     private static final String NAPPA_PACKAGE_NAME = "nl.vu.cs.s2group.nappa";
+    private static final String NAPPA_SAMPLE_APP_PACKAGE_NAME = "nl.vu.cs.s2group.nappa.sample.app";
 
     private InstrumentUtil() {
         throw new IllegalStateException("InstrumentUtil is a utility class and should be instantiated!");
@@ -48,7 +49,10 @@ public final class InstrumentUtil {
             PsiFile[] psiJavaFiles = FilenameIndex.getFilesByName(project, fileName, GlobalSearchScope.projectScope(project));
             // Remove the files from the NAPPA library from the list to process
             psiJavaFiles = Arrays.stream(psiJavaFiles)
-                    .filter(psiJavaFile -> !((PsiJavaFile) psiJavaFile).getPackageName().contains(NAPPA_PACKAGE_NAME))
+                    .filter(psiJavaFile -> {
+                        String packageName = ((PsiJavaFile) psiJavaFile).getPackageName();
+                        return !packageName.contains(NAPPA_PACKAGE_NAME) || packageName.contains(NAPPA_SAMPLE_APP_PACKAGE_NAME);
+                    })
                     .toArray(PsiFile[]::new);
 
             psiFiles.addAll(Arrays.asList(psiJavaFiles));


### PR DESCRIPTION
Adds an exception to include packages under the NAPPA package as long as they are under the `nappa.sample.app` package