### PR TITLE
Update navigation instrumentation to use NAPPA Lifecycle Observer

### DIFF
--- a/Android-Studio-Plugin/build.gradle
+++ b/Android-Studio-Plugin/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'nl.vu.cs.s2group.nappa.plugin'
-version '1.1.3'
+version '1.1.4'
 
 sourceCompatibility = 1.8
 

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
@@ -110,7 +110,7 @@ public class InstrumentActivityAction extends AnAction {
             // There are three cases to inject a navigation probe
             PsiMethod[] psiMethods = psiClass.findMethodsByName("onCreate", false);
             // Case 1. There is no method "onCreate"
-            if (psiMethods.length == 0) injectNavigationProbesWithoutonCreateMethod(psiClass, instrumentedText);
+            if (psiMethods.length == 0) injectNavigationProbesWithoutOnCreateMethod(psiClass, instrumentedText);
             else {
                 PsiCodeBlock psiBody = psiMethods[0].getBody();
                 // Case 2. There is a method "onCreate" and it an empty body
@@ -118,10 +118,10 @@ public class InstrumentActivityAction extends AnAction {
                 // The method "onCreate" will always have a body.
                 // noinspection ConstantConditions
                 if (psiBody.getStatements().length == 0)
-                    injectNavigationProbesWithEmptyonCreateMethod(psiClass, psiBody, instrumentedText);
+                    injectNavigationProbesWithEmptyOnCreateMethod(psiClass, psiBody, instrumentedText);
                     // Case 3. There is a method "onCreate" and it has a non-empty body
                 else
-                    injectNavigationProbesWithNonEmptyonCreateMethod(psiClass, psiBody, instrumentedText);
+                    injectNavigationProbesWithNonEmptyOnCreateMethod(psiClass, psiBody, instrumentedText);
 
                 resultMessage.incrementInstrumentationCount()
                         .appendPsiClass(psiClass)
@@ -139,7 +139,7 @@ public class InstrumentActivityAction extends AnAction {
      * @param psiBody          Represents the body of the method {@code onCreate} found in the class
      * @param instrumentedText Represents the source code to inject
      */
-    private void injectNavigationProbesWithEmptyonCreateMethod(PsiClass psiClass, PsiCodeBlock psiBody, String instrumentedText) {
+    private void injectNavigationProbesWithEmptyOnCreateMethod(PsiClass psiClass, PsiCodeBlock psiBody, String instrumentedText) {
         PsiElement instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createStatementFromText("" +
@@ -158,17 +158,17 @@ public class InstrumentActivityAction extends AnAction {
      * @param psiBody          Represents the body of the method {@code onCreate} found in the class
      * @param instrumentedText Represents the source code to inject
      */
-    private void injectNavigationProbesWithNonEmptyonCreateMethod(PsiClass psiClass, @NotNull PsiCodeBlock psiBody, String instrumentedText) {
+    private void injectNavigationProbesWithNonEmptyOnCreateMethod(PsiClass psiClass, @NotNull PsiCodeBlock psiBody, String instrumentedText) {
         // If there is a super constructor invocation, is must be in the first line of the method
         PsiStatement firstStatement = psiBody.getStatements()[0];
-        boolean isSuperonCreate = firstStatement.getText().contains("super.onCreate(");
+        boolean isSuperOnCreate = firstStatement.getText().contains("super.onCreate(");
 
         PsiElement instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createStatementFromText(instrumentedText, psiClass);
 
         WriteCommandAction.runWriteCommandAction(project, () -> {
-            if (isSuperonCreate) psiBody.addAfter(instrumentedElement, firstStatement);
+            if (isSuperOnCreate) psiBody.addAfter(instrumentedElement, firstStatement);
             else psiBody.addBefore(instrumentedElement, firstStatement);
         });
     }
@@ -179,7 +179,7 @@ public class InstrumentActivityAction extends AnAction {
      * @param psiClass         Represents a Java class.
      * @param instrumentedText Represents the source code to inject
      */
-    private void injectNavigationProbesWithoutonCreateMethod(PsiClass psiClass, String instrumentedText) {
+    private void injectNavigationProbesWithoutOnCreateMethod(PsiClass psiClass, String instrumentedText) {
         PsiMethod instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createMethodFromText("" +

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
@@ -60,42 +60,42 @@ public class InstrumentActivityAction extends AnAction {
     }
 
     /**
-     * This method finds the {@code onResume()} method implemented in an {@link android.app.Activity} and
+     * This method finds the {@code onCreate()} method implemented in an {@link android.app.Activity} and
      * insert an instrumented text to add the navigation probes.There are three instrumentation cases for
      * injecting the navigation probes.
      * <br/><br/>git che
      *
-     * <p> Case 1. The {@link android.app.Activity} don't have the method {@code onResume()}. In this case,
+     * <p> Case 1. The {@link android.app.Activity} don't have the method {@code onCreate()}. In this case,
      * the method is injected containing the super constructor and the navigation probe. The injected code
      * is as follows:
      *
      * <pre>{@code
      * @Override
-     * protected void onResume() {
-     *     super.onResume();
-     *     PrefetchingLib.setCurrentActivity(this);
+     * protected void onCreate(Bundle savedInstanceState) {
+     *     super.onCreate(savedInstanceState);
+     *     getLifecycle().addObserver(new NAPPALifecycleObserver(this));
      * }
      * }</pre>
      *
-     * <p> Case 2. The {@link android.app.Activity} has a method {@code onResume()} with existing source
-     * code. In this case, the navigation probe is inserted at the top of the method {@code onResume()},
+     * <p> Case 2. The {@link android.app.Activity} has a method {@code onCreate()} with existing source
+     * code. In this case, the navigation probe is inserted at the top of the method {@code onCreate()},
      * after invoking the super constructor, if it present, or before the first statement in the method.
      * The injected code is as follows:
      *
-     * <pre>{@code PrefetchingLib.setCurrentActivity(this);}</pre>
+     * <pre>{@code getLifecycle().addObserver(new NAPPALifecycleObserver(this));}</pre>
      *
-     * <p> Case 3. The {@link android.app.Activity} has an empty method {@code onResume()}. In this case,
+     * <p> Case 3. The {@link android.app.Activity} has an empty method {@code onCreate()}. In this case,
      * the super constructor is injected together with the navigation probe. The injected code is as follows:
      *
      * <pre>{@code
-     * super.onResume();
-     * PrefetchingLib.setCurrentActivity(this);
+     * super.onCreate();
+     * getLifecycle().addObserver(new NAPPALifecycleObserver(this));
      * }</pre>
      *
      * @param javaFile The Java file containing the an {@link android.app.Activity}
      */
     private void injectNavigationProbes(@NotNull PsiJavaFile javaFile) {
-        String instrumentedText = "PrefetchingLib.setCurrentActivity(this);";
+        String instrumentedText = "getLifecycle().addObserver(new NAPPALifecycleObserver(this));";
         PsiClass[] psiClasses = javaFile.getClasses();
         for (PsiClass psiClass : psiClasses) {
             // There is only one initialization per app
@@ -108,18 +108,18 @@ public class InstrumentActivityAction extends AnAction {
             if (!InstrumentUtil.isMainPublicClass(psiClass)) continue;
 
             // There are three cases to inject a navigation probe
-            PsiMethod[] psiMethods = psiClass.findMethodsByName("onResume", false);
-            // Case 1. There is no method "onResume"
+            PsiMethod[] psiMethods = psiClass.findMethodsByName("onCreate", false);
+            // Case 1. There is no method "onCreate"
             if (psiMethods.length == 0) injectNavigationProbesWithoutOnResumeMethod(psiClass, instrumentedText);
             else {
                 PsiCodeBlock psiBody = psiMethods[0].getBody();
-                // Case 2. There is a method "onResume" and it an empty body
+                // Case 2. There is a method "onCreate" and it an empty body
                 // Only interfaces and abstracts methods don't have a body.
-                // The method "onResume" will always have a body.
+                // The method "onCreate" will always have a body.
                 // noinspection ConstantConditions
                 if (psiBody.getStatements().length == 0)
                     injectNavigationProbesWithEmptyOnResumeMethod(psiClass, psiBody, instrumentedText);
-                    // Case 3. There is a method "onResume" and it has a non-empty body
+                    // Case 3. There is a method "onCreate" and it has a non-empty body
                 else
                     injectNavigationProbesWithNonEmptyOnResumeMethod(psiClass, psiBody, instrumentedText);
 
@@ -133,17 +133,17 @@ public class InstrumentActivityAction extends AnAction {
     }
 
     /**
-     * Inject the navigation probe to the method {@code onResume} with empty body to the class
+     * Inject the navigation probe to the method {@code onCreate} with empty body to the class
      *
      * @param psiClass         Represents a Java class.
-     * @param psiBody          Represents the body of the method {@code onResume} found in the class
+     * @param psiBody          Represents the body of the method {@code onCreate} found in the class
      * @param instrumentedText Represents the source code to inject
      */
     private void injectNavigationProbesWithEmptyOnResumeMethod(PsiClass psiClass, PsiCodeBlock psiBody, String instrumentedText) {
         PsiElement instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createStatementFromText("" +
-                        "super.onResume();\n" +
+                        "super.onCreate(savedInstanceState);\n" +
                         instrumentedText, psiClass);
 
         WriteCommandAction.runWriteCommandAction(project, () -> {
@@ -152,16 +152,16 @@ public class InstrumentActivityAction extends AnAction {
     }
 
     /**
-     * Inject the navigation probe to the method {@code onResume} containing existing code to the class
+     * Inject the navigation probe to the method {@code onCreate} containing existing code to the class
      *
      * @param psiClass         Represents a Java class.
-     * @param psiBody          Represents the body of the method {@code onResume} found in the class
+     * @param psiBody          Represents the body of the method {@code onCreate} found in the class
      * @param instrumentedText Represents the source code to inject
      */
     private void injectNavigationProbesWithNonEmptyOnResumeMethod(PsiClass psiClass, @NotNull PsiCodeBlock psiBody, String instrumentedText) {
         // If there is a super constructor invocation, is must be in the first line of the method
         PsiStatement firstStatement = psiBody.getStatements()[0];
-        boolean isSuperOnResume = firstStatement.getText().contains("super.onResume(");
+        boolean isSuperOnResume = firstStatement.getText().contains("super.onCreate(");
 
         PsiElement instrumentedElement = PsiElementFactory
                 .getInstance(project)
@@ -174,7 +174,7 @@ public class InstrumentActivityAction extends AnAction {
     }
 
     /**
-     * Inject a {@code onResume} method with the navigation probes to the class
+     * Inject a {@code onCreate} method with the navigation probes to the class
      *
      * @param psiClass         Represents a Java class.
      * @param instrumentedText Represents the source code to inject
@@ -184,8 +184,8 @@ public class InstrumentActivityAction extends AnAction {
                 .getInstance(project)
                 .createMethodFromText("" +
                         "@Override\n" +
-                        "protected void onResume() {\n" +
-                        "super.onResume();\n" +
+                        "protected void onCreate(Bundle savedInstanceState) {\n" +
+                        "super.onCreate(savedInstanceState);\n" +
                         instrumentedText + "\n" +
                         "}", psiClass);
 

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
@@ -52,7 +52,7 @@ public class InstrumentActivityAction extends AnAction {
                     }
                 }
             });
-            resultMessage.showResultDialog(project, "lifecycle observer Instrumentation Result");
+            resultMessage.showResultDialog(project, "Lifecycle Observer Instrumentation Result");
         } catch (Exception exception) {
             resultMessage.showErrorDialog(project, exception, "Failed to Instrument lifecycle observer");
         }

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
@@ -110,7 +110,7 @@ public class InstrumentActivityAction extends AnAction {
             // There are three cases to inject a navigation probe
             PsiMethod[] psiMethods = psiClass.findMethodsByName("onCreate", false);
             // Case 1. There is no method "onCreate"
-            if (psiMethods.length == 0) injectNavigationProbesWithoutOnResumeMethod(psiClass, instrumentedText);
+            if (psiMethods.length == 0) injectNavigationProbesWithoutonCreateMethod(psiClass, instrumentedText);
             else {
                 PsiCodeBlock psiBody = psiMethods[0].getBody();
                 // Case 2. There is a method "onCreate" and it an empty body
@@ -118,10 +118,10 @@ public class InstrumentActivityAction extends AnAction {
                 // The method "onCreate" will always have a body.
                 // noinspection ConstantConditions
                 if (psiBody.getStatements().length == 0)
-                    injectNavigationProbesWithEmptyOnResumeMethod(psiClass, psiBody, instrumentedText);
+                    injectNavigationProbesWithEmptyonCreateMethod(psiClass, psiBody, instrumentedText);
                     // Case 3. There is a method "onCreate" and it has a non-empty body
                 else
-                    injectNavigationProbesWithNonEmptyOnResumeMethod(psiClass, psiBody, instrumentedText);
+                    injectNavigationProbesWithNonEmptyonCreateMethod(psiClass, psiBody, instrumentedText);
 
                 resultMessage.incrementInstrumentationCount()
                         .appendPsiClass(psiClass)
@@ -139,7 +139,7 @@ public class InstrumentActivityAction extends AnAction {
      * @param psiBody          Represents the body of the method {@code onCreate} found in the class
      * @param instrumentedText Represents the source code to inject
      */
-    private void injectNavigationProbesWithEmptyOnResumeMethod(PsiClass psiClass, PsiCodeBlock psiBody, String instrumentedText) {
+    private void injectNavigationProbesWithEmptyonCreateMethod(PsiClass psiClass, PsiCodeBlock psiBody, String instrumentedText) {
         PsiElement instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createStatementFromText("" +
@@ -158,17 +158,17 @@ public class InstrumentActivityAction extends AnAction {
      * @param psiBody          Represents the body of the method {@code onCreate} found in the class
      * @param instrumentedText Represents the source code to inject
      */
-    private void injectNavigationProbesWithNonEmptyOnResumeMethod(PsiClass psiClass, @NotNull PsiCodeBlock psiBody, String instrumentedText) {
+    private void injectNavigationProbesWithNonEmptyonCreateMethod(PsiClass psiClass, @NotNull PsiCodeBlock psiBody, String instrumentedText) {
         // If there is a super constructor invocation, is must be in the first line of the method
         PsiStatement firstStatement = psiBody.getStatements()[0];
-        boolean isSuperOnResume = firstStatement.getText().contains("super.onCreate(");
+        boolean isSuperonCreate = firstStatement.getText().contains("super.onCreate(");
 
         PsiElement instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createStatementFromText(instrumentedText, psiClass);
 
         WriteCommandAction.runWriteCommandAction(project, () -> {
-            if (isSuperOnResume) psiBody.addAfter(instrumentedElement, firstStatement);
+            if (isSuperonCreate) psiBody.addAfter(instrumentedElement, firstStatement);
             else psiBody.addBefore(instrumentedElement, firstStatement);
         });
     }
@@ -179,7 +179,7 @@ public class InstrumentActivityAction extends AnAction {
      * @param psiClass         Represents a Java class.
      * @param instrumentedText Represents the source code to inject
      */
-    private void injectNavigationProbesWithoutOnResumeMethod(PsiClass psiClass, String instrumentedText) {
+    private void injectNavigationProbesWithoutonCreateMethod(PsiClass psiClass, String instrumentedText) {
         PsiMethod instrumentedElement = PsiElementFactory
                 .getInstance(project)
                 .createMethodFromText("" +

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
@@ -54,7 +54,7 @@ public class InstrumentActivityAction extends AnAction {
             });
             resultMessage.showResultDialog(project, "Lifecycle Observer Instrumentation Result");
         } catch (Exception exception) {
-            resultMessage.showErrorDialog(project, exception, "Failed to Instrument lifecycle observer");
+            resultMessage.showErrorDialog(project, exception, "Failed to Instrument Lifecycle Observer");
         }
     }
 

--- a/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
+++ b/Android-Studio-Plugin/src/main/java/nl/vu/cs/s2group/nappa/plugin/action/InstrumentActivityAction.java
@@ -65,7 +65,7 @@ public class InstrumentActivityAction extends AnAction {
      * <br/><br/>git che
      *
      * <p> Case 1. The {@link android.app.Activity} don't have the method {@code onCreate()}. In this case,
-     * the method is injected containing the super constructor and the lifecycle observer . The injected code
+     * the method is injected containing the super constructor and the lifecycle observer. The injected code
      * is as follows:
      *
      * <pre>{@code
@@ -84,7 +84,7 @@ public class InstrumentActivityAction extends AnAction {
      * <pre>{@code getLifecycle().addObserver(new NAPPALifecycleObserver(this));}</pre>
      *
      * <p> Case 3. The {@link android.app.Activity} has an empty method {@code onCreate()}. In this case,
-     * the super constructor is injected together with the lifecycle observer . The injected code is as follows:
+     * the super constructor is injected together with the lifecycle observer. The injected code is as follows:
      *
      * <pre>{@code
      * super.onCreate();


### PR DESCRIPTION
Closes #65 

In PR #62, we implement a Lifecycle observer. This PR updates the Android Studio plugin to inject this observer in the instrumentation.

This action could be simplified since we now instrument the same method for navigation and initialization of the library, however, my current priority is to implement the new prefetching strategies.