### PR TITLE
Fix invoking trigger to register the same activity multiple times.

### DIFF
--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/Nappa.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/Nappa.java
@@ -248,6 +248,7 @@ public class Nappa {
         boolean shouldPrefetch;
         previousActivityName = currentActivityName;
         currentActivityName = activity.getClass().getCanonicalName();
+        registerActivity(currentActivityName);
         //SHOULD PREFETCH IFF THE USER IS MOVING FORWARD
         shouldPrefetch = activityGraph.updateNodes(currentActivityName);
 

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityGraph.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityGraph.java
@@ -174,11 +174,8 @@ public class ActivityGraph {
      * @return {@linkplain ActivityNode} Corresponding to the activity name requested
      */
     public ActivityNode getByName(String activityName) {
-        ActivityNode node = new ActivityNode(activityName);
-        if (nodeList.contains(node)) {
-            return nodeList.get(nodeList.indexOf(node));
-        }
-        throw new RuntimeException("Unable to find node: " + activityName);
+        int nodeIdx = nodeList.indexOf(new ActivityNode(activityName));
+        return  nodeIdx == -1 ? null : nodeList.get(nodeIdx);
     }
 
     public void updateLAR(String activityName) {

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityNode.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/graph/ActivityNode.java
@@ -58,19 +58,12 @@ public class ActivityNode {
     List<AggregateVisitTimeByActivity> successorVisitTimeList;
 
     /**
-     * Initializes the current activity node by creating an object of the activity, and also
-     * by initializing the current activity in the the Prefetchinglib's static hashmap of activities
-     * and the Room database.
-     * <p>
-     * NOTE: Persistence inthe prefetching lib is only performed if the database does not already
-     * contain the activityName
+     * Initializes the current activity node by creating an object of the activity.
      *
      * @param activityName
      */
     public ActivityNode(String activityName) {
         this.activityName = activityName;
-        // Register activity to the prefetching LIB
-        Nappa.registerActivity(activityName);
     }
 
     public void setActivityData(ActivityData activityData) {


### PR DESCRIPTION
Currently, the register activity handler was triggered whenever an `ActivityNode` object was instantiated. This caused the register activity handler to be triggered on multiple occasions -- even when registering the activity. The trigger invocation code block was moved to the navigation monitor, thus invoking it only once per navigation and executing only if the activity is not registered.