### PR TITLE
Allow apps to pass Intent Extras with a null value

### DIFF
--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/Nappa.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/Nappa.java
@@ -370,9 +370,7 @@ public class Nappa {
                     // Put on this extras tracker for this activity the new key-value pair. If
                     //    No value has been associated with this extra, NULL will be stored
                     Object value = allExtras.get(key);
-                    if (value == null)
-                        throw new IllegalArgumentException("Unable to find Intent Extra with key " + key);
-                    extras.put(key, value.toString());
+                    if (value != null) extras.put(key, value.toString());
                 }
 
                 // Update the global extras map after all extras have been stored
@@ -382,7 +380,7 @@ public class Nappa {
                 poolExecutor.schedule(() -> {
                     List<String> toBePrefetched = strategyIntent.getTopNUrlToPrefetchForNode(activityGraph.getCurrent(), 2);
                     for (String url : toBePrefetched) {
-                        Log.d(LOG_TAG, "PREFSTRAT2 " + "URL: " + url);
+                        Log.d(LOG_TAG, String.format("Extras monitor: Prefetching: %s", url));
                     }
                     // Trigger Prefetching
                     if (prefetchEnabled) {
@@ -397,19 +395,18 @@ public class Nappa {
                     for (String key : allExtras.keySet()) {
                         // Create an Database Object and store it
                         Object value = allExtras.get(key);
-                        if (value == null)
-                            throw new IllegalArgumentException("Unable to find Intent Extra with key " + key);
+                        if (value == null) continue;
                         ActivityExtraData activityExtraData =
                                 new ActivityExtraData(session.id, idAct, key, value.toString());
-                        Log.d(LOG_TAG, "PREFSTRAT2 " + "ADDING NEW ACTEXTRADATA");
+                        Log.d(LOG_TAG, String.format("Extras Monitor: Registering extra <%s, %s> for activity %s",
+                                key,
+                                value.toString(),
+                                currentActivityName));
                         NappaDB.getInstance().activityExtraDao().insertActivityExtra(activityExtraData);
                     }
                 }, 0, TimeUnit.SECONDS);
-
             }
-
         }
-
     }
 
     /**


### PR DESCRIPTION
One of the apps selected as subjects for the experiment was passing null values using Intent Extras. There is no rule in Android forbidding to doing so. Therefore, there is no reason for NAPPA to throw an Exception when parsing an Intent Extra with a null value. Instead, NAPPA should just ignore this extra and continue the execution.