### PR TITLE
Improvements and fixes to prefetching strategies

### DIFF
--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/AbstractPrefetchingStrategy.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/AbstractPrefetchingStrategy.java
@@ -4,8 +4,6 @@ import android.util.Log;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Date;
-
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
 import nl.vu.cs.s2group.nappa.util.NappaConfigMap;
 
@@ -98,11 +96,16 @@ public abstract class AbstractPrefetchingStrategy implements PrefetchingStrategy
      *
      * @param activity  The current activity received in {@link #getTopNUrlToPrefetchForNode(ActivityNode, Integer)}
      * @param startTime A timestamp on when the calculations stared.
+     * @param key       An identification of this run. If none, set to -1.
      */
+    protected void logStrategyExecutionDuration(@NotNull ActivityNode activity, long startTime, int key) {
+        Log.d(this.getClass().getSimpleName(), String.format("%sPrefetching strategy executed for node '%s' in %d ms",
+                key != -1 ? String.format("(#%d) ", key) : "",
+                activity.activityName,
+                System.currentTimeMillis() - startTime));
+    }
+
     protected void logStrategyExecutionDuration(@NotNull ActivityNode activity, long startTime) {
-        Log.d(this.getClass().getSimpleName(), "Prefetching strategy calculations for " +
-                activity.getSuccessorsVisitTimeList() +
-                " was finished in " +
-                (new Date().getTime() - startTime) + " ms");
+        logStrategyExecutionDuration(activity, startTime, -1);
     }
 }

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategyOnVisitFrequencyAndTime.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategyOnVisitFrequencyAndTime.java
@@ -74,7 +74,7 @@ public class GreedyPrefetchingStrategyOnVisitFrequencyAndTime extends AbstractPr
 
         executionNumber++;
         int key = executionNumber;
-        Log.w(LOG_TAG, String.format("(#%d) Starting execution %d for node '%s'.", key, key, node.activityName));
+        Log.d(LOG_TAG, String.format("(#%d) Starting execution %d for node '%s'.", key, key, node.activityName));
 
         visitedNodes.put(key, new ArrayList<>());
         selectedUrls.put(key, new ArrayList<>());

--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategyOnVisitFrequencyAndTime.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/prefetch/GreedyPrefetchingStrategyOnVisitFrequencyAndTime.java
@@ -5,10 +5,9 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import nl.vu.cs.s2group.nappa.graph.ActivityNode;
 import nl.vu.cs.s2group.nappa.util.NappaConfigMap;
@@ -35,6 +34,16 @@ public class GreedyPrefetchingStrategyOnVisitFrequencyAndTime extends AbstractPr
     protected final float weightFrequencyScore;
     protected final float weightTimeScore;
 
+    /*
+     * The Extras and Navigation monitors triggers the strategy at similar time and might conflict
+     * with each other. This map is a quick fix to ensure that each triggered prefetcher modifies
+     * only its data. This will add a few milliseconds to the total duration, but will keep the run
+     * consistent.
+     */
+    private Map<Integer, List<String>> visitedNodes;
+    private Map<Integer, List<String>> selectedUrls;
+    private int executionNumber = 0;
+
     @Override
     public boolean needVisitTime() {
         return true;
@@ -53,16 +62,31 @@ public class GreedyPrefetchingStrategyOnVisitFrequencyAndTime extends AbstractPr
 
         if ((weightFrequencyScore + weightTimeScore) != 1.0)
             throw new IllegalArgumentException("The sum of the time and frequency weight must be 1!");
+
+        visitedNodes = new HashMap<>();
+        selectedUrls = new HashMap<>();
     }
 
     @NonNull
     @Override
     public List<String> getTopNUrlToPrefetchForNode(@NonNull ActivityNode node, Integer maxNumber) {
-        long startTime = new Date().getTime();
+        long startTime = System.currentTimeMillis();
 
-        List<String> urls = getTopNUrlToPrefetchForNode(node, 1, new ArrayList<>());
-        logStrategyExecutionDuration(node, startTime);
+        executionNumber++;
+        int key = executionNumber;
+        Log.w(LOG_TAG, String.format("(#%d) Starting execution %d for node '%s'.", key, key, node.activityName));
 
+        visitedNodes.put(key, new ArrayList<>());
+        selectedUrls.put(key, new ArrayList<>());
+
+        getTopNUrlToPrefetchForNode(node, 1, key);
+        List<String> urls = selectedUrls.get(key);
+
+        selectedUrls.remove(key);
+        visitedNodes.remove(key);
+
+        logStrategyExecutionDuration(node, startTime, key);
+        //noinspection ConstantConditions
         return urls;
     }
 
@@ -72,7 +96,7 @@ public class GreedyPrefetchingStrategyOnVisitFrequencyAndTime extends AbstractPr
      * The first stage is to find the successor of the current node with the best score.
      * If no successor is found or if the score of the best successor is insufficient
      * (i.e., the calculated score is lower than the lower bound threshold), then the recursion
-     * stops and the current list of URLs is returned.
+     * stops.
      * <p>
      * If the score is higher, then the second stage starts. In this stage the method verifies
      * if there is sufficient budget (i.e., number of URLs) to add all URLs of the best successor.
@@ -81,60 +105,107 @@ public class GreedyPrefetchingStrategyOnVisitFrequencyAndTime extends AbstractPr
      * <p>
      * In the third stage the method verifies whether to continue the recursion or return the
      * current URL list. If the URL budget is completely filled, then the URL list is returned,
-     * otherwise, the recursion continues by invoking this method with the best successor object,
-     * score and current URL list
+     * otherwise, the recursion continues by invoking this method with the best successor object
+     * and its score.
      *
      * @param node        The current node in the recursion. Either the node that started the
      *                    recursion or of of its descendant
      * @param parentScore The score of the parent node.
-     * @param urlList     The list of URLs to prefetch
-     * @return The {@code urlList} after completing all recursions
+     * @param key         An ID representing the visited nodes and selected URLs entries for this
+     *                    execution
      */
-    private List<String> getTopNUrlToPrefetchForNode(@NonNull ActivityNode node, float parentScore, List<String> urlList) {
-        // Fetches the data to start the calculations - Aggregate visit time and frequency
-        float totalAggregateTime = NappaUtil.getSuccessorsAggregateVisitTime(node);
-        int totalAggregateFrequency = NappaUtil.getSuccessorsTotalAggregateVisitFrequency(node, lastNSessions);
-        Map<String, Integer> successorsAggregateFrequencyMap = NappaUtil.mapSuccessorsAggregateVisitFrequency(node, lastNSessions);
+    private void getTopNUrlToPrefetchForNode(@NonNull ActivityNode node, float parentScore, int key) {
+        // Verifies if this node was already been visited -- recursion found a loop
+        if (isNodeVisited(key, node.activityName)) return;
+        addVisitedNode(key, node.activityName);
+
+        if (node.successors.isEmpty()) return;
+
         // Temporary variables to find the best successor
         ActivityNode bestSuccessor = null;
         float bestSuccessorScore = 0;
 
-        // Loop all successors and saves the successor with the best score. In case of drawn, the
-        //  first current best successor is picked
-        for (ActivityNode successor : node.successors.keySet()) {
-            Integer successorFrequency = successorsAggregateFrequencyMap.get(successor.activityName);
-            if (successorFrequency == null)
-                throw new NoSuchElementException("Unable to obtain the successor frequency count!");
-            float successorTime = successor.getAggregateVisitTime().totalDuration;
+        /*
+         * If the current node has only one successor, then the successor score will be always equal
+         * to the parent score. This means we don't need to run the calculations and fetch the
+         * aggregate spent time and visit frequency. To ensure that the scores get lower and lower
+         * as we traverse deeper in the graph, we take only 90% of the parent score for the next
+         * recursion. This percentage was arbitrarily selected.
+         */
+        if (node.successors.size() == 1) {
+            bestSuccessor = node.successors.keySet().iterator().next();
+            bestSuccessorScore = parentScore * 0.9f;
+        } else {
+            // Fetches the data to start the calculations
+            // Represents the total aggregate time spent visiting all successors from current node
+            float totalAggregateTime = NappaUtil.getSuccessorsAggregateVisitTime(node);
 
-            float successorTimeScore = totalAggregateTime == 0 ? 0 : (successorTime / totalAggregateTime * weightTimeScore);
-            float successorFrequencyScore = totalAggregateFrequency == 0 ? 0 : ((float) successorFrequency / totalAggregateFrequency * weightFrequencyScore);
+            // Represents the total aggregate visit frequency from all successors from current node
+            int totalAggregateFrequency = NappaUtil.getSuccessorsTotalAggregateVisitFrequency(node, lastNSessions);
 
-            float successorScore = parentScore * (successorTimeScore + successorFrequencyScore);
+            // Represents a map with <activity name, visit frequency> for each successor
+            Map<String, Integer> successorsAggregateFrequencyMap = NappaUtil.mapSuccessorsAggregateVisitFrequency(node, lastNSessions);
 
-            if (bestSuccessor == null || successorScore > bestSuccessorScore) {
-                bestSuccessor = successor;
-                bestSuccessorScore = successorScore;
+            /*
+             * Loop all successors and saves the successor with the best score. In case of drawn,
+             * the current best successor is picked
+             */
+            for (ActivityNode successor : node.successors.keySet()) {
+                float successorTime = successor.getAggregateVisitTime().totalDuration;
+                Integer successorFrequency = successorsAggregateFrequencyMap.get(successor.activityName);
+                if (successorFrequency == null) {
+                    Log.w(LOG_TAG, String.format("(#%d) Unknown visit frequency count for node '%s'. ", key, successor.activityName));
+                    successorFrequency = 0;
+                }
+
+                float successorTimeScore = totalAggregateTime == 0 ? 0 : (successorTime / totalAggregateTime) * weightTimeScore;
+                float successorFrequencyScore = totalAggregateFrequency == 0 ? 0 : ((float) successorFrequency / totalAggregateFrequency) * weightFrequencyScore;
+
+                float successorScore = parentScore * (successorTimeScore + successorFrequencyScore);
+
+                if (bestSuccessor == null || successorScore > bestSuccessorScore) {
+                    bestSuccessor = successor;
+                    bestSuccessorScore = successorScore;
+                }
             }
         }
 
         // Verifies if this node has any successor. If it has, verifies if the successor with the best score has a score high enough
-        if (bestSuccessor == null || bestSuccessorScore < scoreLowerThreshold) return urlList;
+        if (bestSuccessor == null || bestSuccessorScore < scoreLowerThreshold) return;
 
         // Fetches the URLs from the bestSuccessor and the remaining URL budget
-        int remainingUrlBudget = maxNumberOfUrlToPrefetch - urlList.size();
+        List<String> urls = selectedUrls.get(key);
+        //noinspection ConstantConditions
+        int remainingUrlBudget = maxNumberOfUrlToPrefetch - urls.size();
         List<String> bestSuccessorUrls = NappaUtil.getUrlsFromCandidateNode(node, bestSuccessor, remainingUrlBudget);
 
-        Log.d(LOG_TAG, node.activityName +
-                " best successor is " + bestSuccessor.activityName +
-                " with score " + bestSuccessorScore +
-                " containing the URLS " + bestSuccessorUrls);
+        Log.d(LOG_TAG, String.format("(#%d) The best successor for activity '%s' is node '%s' with a score of %f and the following %d URLS: %s",
+                key,
+                node.activityName,
+                bestSuccessor.activityName,
+                bestSuccessorScore,
+                bestSuccessorUrls.size(),
+                bestSuccessorUrls
+        ));
 
         // Add the remaining URLs to the list of URLs to prefetch
-        urlList.addAll(bestSuccessorUrls);
+        urls.addAll(bestSuccessorUrls);
+        selectedUrls.put(key, urls);
 
         // Verifies if there is any URL budget left
-        if (urlList.size() >= maxNumberOfUrlToPrefetch) return urlList;
-        return getTopNUrlToPrefetchForNode(bestSuccessor, bestSuccessorScore, urlList);
+        if (urls.size() >= maxNumberOfUrlToPrefetch) return;
+        getTopNUrlToPrefetchForNode(bestSuccessor, bestSuccessorScore, key);
+    }
+
+    private void addVisitedNode(int key, String nodeName) {
+        List<String> list = visitedNodes.get(key);
+        //noinspection ConstantConditions
+        list.add(nodeName);
+        visitedNodes.put(key, list);
+    }
+
+    private boolean isNodeVisited(int key, String nodeName) {
+        //noinspection ConstantConditions
+        return visitedNodes.get(key).contains(nodeName);
     }
 }


### PR DESCRIPTION
## Greedy Strategy in Time and Frequency

### Only run score calculations if needed.
If the current node doesn't have any successor or it has only a single successor, then there is no need to run the score calculations. For the first case (no successor), end the recursion and return the URL list selected so far. For the second case (single successor), this node will be the best successor and its score will be equal to the parent score. The successor score will receive 90% of the parent score in order to ensure that we don't traverse too deeply in the graph when running the strategy for a list of nodes (i.e., the path in the graph is composed of nodes with a single child). In this scenario, by multiplying the scores by 90% on each recursion, there will be at most 5 consecutive recursions as 0.9^5 < 0.6. The value of 90% was arbitrarily selected.

### If a node was already visited, terminate the recursion
If the current path in the graph is part of a (small) closed-loop, then the recursion will visit the same nodes multiple times. The previous item partially solves this issue if all nodes in the loop have a single child only. However, this is not always the case. Therefore, to avoid repeating calculations, URLs and recursions, keep a list of visited nodes. If the current node in the recursion has already been visited, end the recursion and return the URL list selected so far.

### Reduce recursion stack.
There is no need to create a copy of the URL list in the stack of each recursion. We can keep this data as a list in the class attributes. I don't know if this will have a positive impact in terms of memory consumption. Since we keep one list instead of multiple, there should not be any negative impact.

### Ensure consistency between runs triggered by the navigation and extras monitors.
When providing all extras at once, NAPPA triggers the Intent Extras monitor a few milliseconds before the navigation monitor. When providing each extra individually, the same can occur, triggering the prefetcher by each extra. With updates (2) and (3), this can cause different runs to conflict with each other. To ensure consistency between runs and keep the data of each run isolated, the visited nodes and selected URLs lists were encapsulated under a map, using an incremental run number as keys. This key is passed down the recursion and each recursion access only its entry in the map. After completing the recursion, the URL list is retrieved and the entries of both lists in the maps are removed.

### Fixes the score calculation
There was a typo when calculating the scores, resulting in the Greedy score being larger than it should.

## TFPR strategy

### Lower the default threshold to 30%
Preliminary runs with 7 real-world open-source Android apps showed that the majority of the apps calculated a score between 30% to 40% for the navigated activities.

### The list of best nodes was being sorted from the lowest to the highest
When the SDK was downgraded to level 23, the comparator was incorrectly replaced. This commit fixes the comparator to sort the nodes from the highest to the lowest score.

### Only run algorithm and scores calculations if needed
If the current node doesn't have any successor, there is no need to generate a subgraph, calculate the aggregate times and run the TFPR algorithm. Prior to executing any of these tasks, verify if the current node has any successor.