### PR TITLE
Ensures the execution is not interrupted by an Exception

### DIFF
--- a/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/room/dao/UrlCandidateDao.java
+++ b/Prefetching-Library/android_prefetching_lib/src/main/java/nl/vu/cs/s2group/nappa/room/dao/UrlCandidateDao.java
@@ -78,6 +78,11 @@ public interface UrlCandidateDao {
             // For each parameter in the parameter list,  build a parameteredUrl object and store it
             //  in the hashmap
             for (UrlCandidateToUrlParameter parameter : parameterList) {
+                /*
+                 * This verification is a quick fix for avoiding throwing an exception here. This
+                 * needs investigation on why there was a null value here.
+                 */
+                if (parameter.urlPiece == null) continue;
 
                 ParameteredUrl parameteredUrl = parameteredUrlHashMap.get(parameter.id);
                 if (parameteredUrl == null) {


### PR DESCRIPTION
As added in the comments, this is a quick fix. I did not have the time to investigate why a NullPointException was being thrown here in the first place. I assume that we don't want null URL pieces since they don't add any value to NAPPA's prefetching abilities. In future, the initialization and management of URL pieces need to be debugged to verify where null values were accepted and saved.